### PR TITLE
Merge branch "box_shadow_not_working"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
 
 [dependencies]
-webrender = { git = "https://github.com/servo/webrender", rev = "9c9b97a5950899cdc57837e9237e9c020f1aee83" }
+webrender = { git = "https://github.com/servo/webrender", rev = "ef7edeb649d12a963dc162e08fc08ec6d0de9cf0" }
 cassowary = "0.3.0"
 simplecss = "0.1.0"
 twox-hash = "1.1.0"

--- a/examples/test_content.css
+++ b/examples/test_content.css
@@ -3,7 +3,8 @@
     color: #000000;
     border: 1px solid #b7b7b7;
     border-radius: 4px;
-    box-shadow: 0px 0px 3px #c5c5c5ad;
+    /*box-shadow: 0px 0px 3px #c5c5c5ad;*/
+    box-shadow: 0px 0px 3px red;
     background: linear-gradient(#fcfcfc, #efefef);
     width: 200px;
     height: 200px;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![deny(unused_must_use)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
+#![allow(unused_variables)]
 
 extern crate webrender;
 extern crate cassowary;


### PR DESCRIPTION
The branch existed because I thought that the box shadow wasn't working. I didn't notice that the box shadow iin webrender hasn't worked since at least https://github.com/servo/webrender/commit/9c9b97a5950899cdc57837e9237e9c020f1aee83. 

The box shadow still doesn't work, but it's not critical. It seems that calling `DisplayListBuilder::push_box_shadow()` simply does nothing - or I am using the wrong units. 

Also fixed the wrong startup behaviour and made Vsync / SRGB optional on platforms they don't work on.