### PR TITLE
Minor edits to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Rust Compiler Version](https://img.shields.io/badge/rustc-1.28%20stable-blue.svg)]()
 <!-- [END badges] -->
 
-> Azul is a free, functional, immediate mode GUI framework utilizing the Mozilla WebRender rendering engine for rapid development
+> Azul is a free, functional, immediate mode GUI framework that is built on the Mozilla WebRender rendering engine for rapid development
 of desktop applications that are written in Rust and use a CSS / DOM model for layout and styling.
 
 ###### [Website](https://azul.rs/) | [Tutorial / user guide](https://github.com/maps4print/azul/wiki) | [Video demo](https://www.youtube.com/watch?v=kWL0ehf4wwI) | [Discord Chat](https://discord.gg/nxUmsCG)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 <!-- [END badges] -->
 
 > Azul is a free, functional, immediate mode GUI framework for rapid development
-of desktop applications written in Rust, supported by the Mozilla WebRender rendering
-engine, using a CSS / DOM model for layout and styling.
+of desktop applications written in Rust and supported by the Mozilla WebRender rendering
+engine. Azul uses a CSS / DOM model for layout and styling.
 
 ###### [Website](https://azul.rs/) | [Tutorial / user guide](https://github.com/maps4print/azul/wiki) | [Video demo](https://www.youtube.com/watch?v=kWL0ehf4wwI) | [Discord Chat](https://discord.gg/nxUmsCG)
 
@@ -83,7 +83,7 @@ fn main() {
 
 ## Programming model
 
-In order to comply with Rusts mutability rules, the application lifecycle in Azul
+In order to comply with Rust's mutability rules, the application lifecycle in Azul
 consists of three states that are called over and over again. The framework determines
 exactly when a repaint is necessary, you don't need to worry about manually repainting
 your UI:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Rust Compiler Version](https://img.shields.io/badge/rustc-1.28%20stable-blue.svg)]()
 <!-- [END badges] -->
 
-> Azul is a free, functional, immediate mode GUI framework for rapid development
-of desktop applications written in Rust and supported by the Mozilla WebRender rendering
-engine. Azul uses a CSS / DOM model for layout and styling.
+> Azul is a free, functional, immediate mode GUI framework utilizing the Mozilla WebRender rendering engine for rapid development
+of desktop applications that are written in Rust and use a CSS / DOM model for layout and styling.
 
 ###### [Website](https://azul.rs/) | [Tutorial / user guide](https://github.com/maps4print/azul/wiki) | [Video demo](https://www.youtube.com/watch?v=kWL0ehf4wwI) | [Discord Chat](https://discord.gg/nxUmsCG)
 


### PR DESCRIPTION
"Rusts" --> "Rust's" (in the "Programming Model" section)
Edited the first paragraph for more clarity. I think you were saying that Azul supports development of desktop apps that were written in Rust AND were supported by the Mozilla WebRender rendering engine, but the original sentence was unclear about that. I rewrote that part and then wrote about Azul using a CSS/DOM model in a separate sentence. It's to be clear that Azul uses the model, not the desktop apps (if that was what you meant).

Fixes #43 