### PR TITLE
add hsl and hsla style colors

### DIFF
--- a/src/css_parser.rs
+++ b/src/css_parser.rs
@@ -960,7 +960,7 @@ fn parse_color_builtin<'a>(input: &'a str)
 }
 
 /// Parse a color of the form 'rgb([0-255], [0-255], [0-255])', or 'rgba([0-255], [0-255], [0-255],
-/// [0.-1.])' without the leading 'rgb[a](' or trailing ')'. Alpha defaults to 255.
+/// [0.0-1.0])' without the leading 'rgb[a](' or trailing ')'. Alpha defaults to 255.
 fn parse_color_rgb<'a>(input: &'a str, parse_alpha: bool)
 -> Result<ColorU, CssColorParseError<'a>>
 {
@@ -1001,7 +1001,7 @@ fn parse_color_rgb_components<'a>(components: &mut Iterator<Item = &'a str>)
     })
 }
 
-/// Parse a color of the form 'hsl([0.-360.]deg, [0-100]%, [0-100]%)', or 'hsla([0.-360.]deg, [0-100]%, [0-100]%, [0.-1.])' without the leading 'hsl[a](' or trailing ')'. Alpha defaults to 255.
+/// Parse a color of the form 'hsl([0.0-360.0]deg, [0-100]%, [0-100]%)', or 'hsla([0.0-360.0]deg, [0-100]%, [0-100]%, [0.0-1.0])' without the leading 'hsl[a](' or trailing ')'. Alpha defaults to 255.
 fn parse_color_hsl<'a>(input: &'a str, parse_alpha: bool)
 -> Result<ColorU, CssColorParseError<'a>>
 {
@@ -1054,28 +1054,28 @@ fn parse_color_hsl_components<'a>(components: &mut Iterator<Item = &'a str>)
     /// Adapted from [https://en.wikipedia.org/wiki/HSL_and_HSV#Converting_to_RGB]
     #[inline]
     fn hsl_to_rgb<'a>(h: f32, s: f32, l: f32) -> (u8, u8, u8) {
-        let s = s / 100.;
-        let l = l / 100.;
-        let c = (1. - (2. * l - 1.).abs()) * s;
-        let h = h / 60.;
-        let x = c * (1. - ((h % 2.) - 1.).abs());
+        let s = s / 100.0;
+        let l = l / 100.0;
+        let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+        let h = h / 60.0;
+        let x = c * (1.0 - ((h % 2.0) - 1.0).abs());
         let (r1, g1, b1) = match h as u8 {
-            0 => (c, x, 0.),
-            1 => (x, c, 0.),
-            2 => (0., c, x),
-            3 => (0., x, c),
-            4 => (x, 0., c),
-            5 => (c, 0., x),
+            0 => (c, x, 0.0),
+            1 => (x, c, 0.0),
+            2 => (0.0, c, x),
+            3 => (0.0, x, c),
+            4 => (x, 0.0, c),
+            5 => (c, 0.0, x),
             _ => {
                 println!("h is {}", h);
                 unreachable!();
             }
         };
-        let m = l - c / 2.;
+        let m = l - c / 2.0;
         (
-            ((r1 + m) * 256.).min(255.) as u8,
-            ((g1 + m) * 256.).min(255.) as u8,
-            ((b1 + m) * 256.).min(255.) as u8,
+            ((r1 + m) * 256.0).min(255.0) as u8,
+            ((g1 + m) * 256.0).min(255.0) as u8,
+            ((b1 + m) * 256.0).min(255.0) as u8,
         )
     }
 
@@ -1097,10 +1097,10 @@ fn parse_alpha_component<'a>(components: &mut Iterator<Item=&'a str>) -> Result<
         return Err(CssColorParseError::MissingColorComponent(CssColorComponent::Alpha));
     }
     let a = a.parse::<f32>()?;
-    if a < 0. || a > 1. {
+    if a < 0.0 || a > 1.0 {
         return Err(CssColorParseError::FloatValueOutOfRange(a));
     }
-    let a = (a * 256.).min(255.) as u8;
+    let a = (a * 256.0).min(255.0) as u8;
     Ok(a)
 }
 
@@ -3181,7 +3181,7 @@ mod css_tests {
 
     #[test]
     fn test_parse_css_color_6() {
-        assert_eq!(parse_css_color("rgba(192, 14, 12, 80)"), Err(CssColorParseError::FloatValueOutOfRange(80.)));
+        assert_eq!(parse_css_color("rgba(192, 14, 12, 80)"), Err(CssColorParseError::FloatValueOutOfRange(80.0)));
     }
 
     #[test]

--- a/src/css_parser.rs
+++ b/src/css_parser.rs
@@ -463,7 +463,7 @@ pub enum CssColorParseError<'a> {
     MissingColorComponent(CssColorComponent),
     ExtraArguments(&'a str),
     UnclosedColor(&'a str),
-    DirectionParseError(String),
+    DirectionParseError(CssDirectionParseError<'a>),
     UnsupportedDirection(&'a str),
     InvalidPercentage(&'a str),
 }
@@ -499,11 +499,7 @@ impl<'a> From<ParseFloatError> for CssColorParseError<'a> {
     }
 }
 
-impl<'a> From<CssDirectionParseError<'a>> for CssColorParseError<'a> {
-    fn from(e: CssDirectionParseError) -> Self {
-        CssColorParseError::DirectionParseError(format!("{:?}", e))
-    }
-}
+impl_from!(CssDirectionParseError<'a>, CssColorParseError::DirectionParseError);
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CssImageParseError<'a> {
@@ -3322,7 +3318,7 @@ mod css_tests {
 
     #[test]
     fn test_parse_css_color_27() {
-        assert_eq!(parse_css_color("hsla(240, 0%, 0%, 0.5)"), Err(CssColorParseError::DirectionParseError("InvalidArguments(\"240\")".to_owned())));
+        assert_eq!(parse_css_color("hsla(240, 0%, 0%, 0.5)"), Err(CssColorParseError::DirectionParseError(parse_direction("240").err().unwrap())));
     }
 
     #[test]

--- a/src/css_parser.rs
+++ b/src/css_parser.rs
@@ -3120,6 +3120,40 @@ mod css_tests {
     }
 
     #[test]
+    fn test_parse_linear_gradient_7() {
+        assert_eq!(parse_css_background("linear-gradient(10deg, rgb(10, 30, 20), yellow)"),
+            Ok(StyleBackground::LinearGradient(LinearGradientPreInfo {
+                direction: Direction::Angle(FloatValue::new(10.0)),
+                extend_mode: ExtendMode::Clamp,
+                stops: vec![GradientStopPre {
+                    offset: Some(PercentageValue::new(0.0)),
+                    color: ColorU { r: 10, g: 30, b: 20, a: 255 },
+                },
+                GradientStopPre {
+                    offset: Some(PercentageValue::new(100.0)),
+                    color: ColorU { r: 255, g: 255, b: 0, a: 255 },
+                }],
+        })));
+    }
+
+    #[test]
+    fn test_parse_linear_gradient_8() {
+        assert_eq!(parse_css_background("linear-gradient(50deg, rgb(10, 30, 20, 0.93), hsla(40deg, 80%, 30%, 0.1))"),
+            Ok(StyleBackground::LinearGradient(LinearGradientPreInfo {
+                direction: Direction::Angle(FloatValue::new(40.0)),
+                extend_mode: ExtendMode::Clamp,
+                stops: vec![GradientStopPre {
+                    offset: Some(PercentageValue::new(0.0)),
+                    color: ColorU { r: 10, g: 30, b: 20, a: 238 },
+                },
+                GradientStopPre {
+                    offset: Some(PercentageValue::new(100.0)),
+                    color: ColorU { r: 138, g: 97, b: 15, a: 25 },
+                }],
+        })));
+    }
+
+    #[test]
     fn test_parse_radial_gradient_1() {
         assert_eq!(parse_css_background("radial-gradient(circle, lime, blue, yellow)"),
             Ok(StyleBackground::RadialGradient(RadialGradientPreInfo {

--- a/src/css_parser.rs
+++ b/src/css_parser.rs
@@ -1045,10 +1045,9 @@ fn parse_color_hsl_components<'a>(components: &mut Iterator<Item = &'a str>)
         if c.is_empty() {
             return Err(CssColorParseError::MissingColorComponent(which));
         }
-        match parse_percentage(c) {
-            Some(percentage) => Ok(percentage.get()),
-            None => Err(CssColorParseError::InvalidPercentage(c)),
-        }
+        parse_percentage(c)
+            .ok_or(CssColorParseError::InvalidPercentage(c))
+            .and_then(|p| Ok(p.get()))
     }
 
     /// Adapted from [https://en.wikipedia.org/wiki/HSL_and_HSV#Converting_to_RGB]


### PR DESCRIPTION
Since I noticed I already completed half of [this](https://github.com/maps4print/azul/projects/1#card-14458242), I figured I would go ahead and finish it by adding hsl() and hsla().