### PR TITLE
Implemented Scrolling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,7 @@ required-features = []
 [[example]]
 name = "dragger"
 required-features = []
+
+[[example]]
+name = "scroll_list"
+required-features = []

--- a/examples/scroll_list.css
+++ b/examples/scroll_list.css
@@ -2,20 +2,12 @@
     font-size: 14.66px;
     font-family: sans-serif;
     color: #000;
-    background-color: #f0f0f0; /* Windows Background color, rgb(240, 240, 240) */
 }
 
-.__azul-native-label {
-    text-align: center;
-    flex-direction: column;
-    justify-content: center;
-}
-
-.selected {
-    background-color: black;
-    color: white;
-    width: 300px;
-    height: 170px;
+#container {
+    background-color: red;
+    height: 200px;
+    width: 800px;
 }
 
 .item {
@@ -23,10 +15,12 @@
     color: black;
     width: 300px;
     height: 170px;
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
 }
 
-#container {
-    height: 200px;
-    width: 400px;
-    background-color: red;
+#selected {
+    background-color: black;
+    color: white;
 }

--- a/examples/scroll_list.css
+++ b/examples/scroll_list.css
@@ -1,0 +1,32 @@
+* {
+    font-size: 14.66px;
+    font-family: sans-serif;
+    color: #000;
+    background-color: #f0f0f0; /* Windows Background color, rgb(240, 240, 240) */
+}
+
+.__azul-native-label {
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.selected {
+    background-color: black;
+    color: white;
+    width: 300px;
+    height: 150px;
+}
+
+.item {
+    background-color: white;
+    color: black;
+    width: 300px;
+    height: 150px;
+}
+
+#container {
+    height: 200px;
+    width: 400px;
+    background-color: red;
+}

--- a/examples/scroll_list.css
+++ b/examples/scroll_list.css
@@ -15,14 +15,14 @@
     background-color: black;
     color: white;
     width: 300px;
-    height: 150px;
+    height: 170px;
 }
 
 .item {
     background-color: white;
     color: black;
     width: 300px;
-    height: 150px;
+    height: 170px;
 }
 
 #container {

--- a/examples/scroll_list.css
+++ b/examples/scroll_list.css
@@ -6,8 +6,8 @@
 
 #container {
     background-color: red;
-    height: 200px;
-    width: 800px;
+    height: 400px;
+    width: 600px;
 }
 
 .item {

--- a/examples/scroll_list.rs
+++ b/examples/scroll_list.rs
@@ -12,13 +12,16 @@ impl Layout for List {
         let child_nodes = self.items.iter().enumerate().map(|(idx, item)| {
             NodeData {
                 node_type: NodeType::Label(item.to_string()),
-                classes: if self.selected == Some(idx) { vec!["selected".into()] } else { vec!["item".into()] },
+                classes: vec!["item".into()],
+                ids: if self.selected == Some(idx) { vec!["selected".into()] } else { vec![] },
                 force_enable_hit_test: vec![On::MouseDown],
                 .. Default::default()
             }
         }).collect::<Dom<Self>>()
         .with_callback(On::MouseDown, Callback(print_which_item_was_selected));
+
         Dom::new(NodeType::Div).with_id("container").with_child(child_nodes)
+
     }
 }
 

--- a/examples/scroll_list.rs
+++ b/examples/scroll_list.rs
@@ -1,0 +1,69 @@
+extern crate azul;
+
+use azul::prelude::*;
+
+struct List {
+    items: Vec<&'static str>,
+    selected: Option<usize>,
+}
+
+impl Layout for List {
+    fn layout(&self, _: WindowInfo<Self>) -> Dom<Self> {
+        let child_nodes = self.items.iter().enumerate().map(|(idx, item)| {
+            NodeData {
+                node_type: NodeType::Label(item.to_string()),
+                classes: if self.selected == Some(idx) { vec!["selected".into()] } else { vec!["item".into()] },
+                force_enable_hit_test: vec![On::MouseDown],
+                .. Default::default()
+            }
+        }).collect::<Dom<Self>>()
+        .with_callback(On::MouseDown, Callback(print_which_item_was_selected));
+        Dom::new(NodeType::Div).with_id("container").with_child(child_nodes)
+    }
+}
+
+fn print_which_item_was_selected(app_state: &mut AppState<List>, event: WindowEvent<List>) -> UpdateScreen {
+
+    let selected = event.get_first_hit_child(event.hit_dom_node, On::MouseDown).and_then(|x| Some(x.0));
+    let mut should_redraw = UpdateScreen::DontRedraw;
+
+    app_state.data.modify(|state| {
+        if selected != state.selected {
+            state.selected = selected;
+            should_redraw = UpdateScreen::Redraw;
+        }
+        println!("selected item: {:?}", state.selected);
+    });
+
+    should_redraw
+}
+
+fn main() {
+    let data = List {
+        items: vec![
+            "Hello",
+            "World",
+            "my",
+            "name",
+            "is",
+            "Lorem",
+            "Ipsum",
+            "Dolor",
+            "Sit",
+            "Amet",
+        ],
+        selected: None,
+    };
+
+    let app = App::new(data, AppConfig::default());
+
+    macro_rules! CSS_PATH { () => (concat!(env!("CARGO_MANIFEST_DIR"), "/examples/scroll_list.css")) }
+
+    #[cfg(debug_assertions)]
+    let css = Css::hot_reload_override_native(CSS_PATH!()).unwrap();
+    #[cfg(not(debug_assertions))]
+    let css = Css::new_from_str(include_str!(CSS_PATH!())).unwrap();
+
+    let window = Window::new(WindowCreateOptions::default(), css).unwrap();
+    app.run(window).unwrap();
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -827,19 +827,21 @@ fn render<T: Layout>(
 
     txn.set_root_pipeline(window.internal.pipeline_id);
 
-    txn.scroll(
-        ScrollLocation::Delta(LayoutVector2D::new(10.0, 10.0)),
-        // TODO: change this line as soon as the scroll events are triggering the rerender.
-        //ScrollLocation::Delta(LayoutVector2D::new(window.state.mouse_state.scroll_x as f32, window.state.mouse_state.scroll_y as f32)),
-        TypedPoint2D::new(window.state.mouse_state.cursor_pos.unwrap().x as f32, window.state.mouse_state.cursor_pos.unwrap().y as f32),
-    );
-    println!(
-        "{}, {}, {}, {}",
-        window.state.mouse_state.cursor_pos.unwrap().x as f32,
-        window.state.mouse_state.cursor_pos.unwrap().y as f32,
-        window.state.mouse_state.scroll_x as f32,
-        window.state.mouse_state.scroll_y as f32
-    );
+    if let Some(cursor_position) = window.state.mouse_state.cursor_pos {
+        txn.scroll(
+            ScrollLocation::Delta(LayoutVector2D::new(10.0, -10.0)),
+            // TODO: change this line as soon as the scroll events are triggering the rerender.
+            //ScrollLocation::Delta(LayoutVector2D::new(window.state.mouse_state.scroll_x as f32, window.state.mouse_state.scroll_y as f32)),
+            TypedPoint2D::new(cursor_position.x as f32, cursor_position.y as f32),
+        );
+        println!(
+            "{}, {}, {}, {}",
+            cursor_position.x as f32,
+            cursor_position.y as f32,
+            window.state.mouse_state.scroll_x as f32,
+            window.state.mouse_state.scroll_y as f32
+        );
+    }
     txn.generate_frame();
 
     window.internal.api.send_transaction(window.internal.document_id, txn);

--- a/src/app.rs
+++ b/src/app.rs
@@ -261,12 +261,11 @@ impl<T: Layout> App<T> {
 
                     // Scroll for the scrolled amount for each node that registered a scroll state.
                     let MouseState { scroll_x, scroll_y, .. } = window.state.mouse_state;
-                    //println!("{:?}", window.state.mouse_state);
                     if scroll_x + scroll_y != 0.0 {
-                        let keys = window.scroll_states.keys().map(|k| *k).collect::<Vec<_>>();
+                        let keys = window.scroll_states.0.keys().map(|k| *k).collect::<Vec<_>>();
                         for key in &keys {
                             println!("Scroll");
-                            window.scroll_node(key, scroll_x as f32, scroll_y as f32);
+                            window.scroll_states.scroll_node(key, scroll_x as f32, scroll_y as f32);
                         }
                     }
                 }
@@ -834,21 +833,28 @@ fn render<T: Layout>(
 
     txn.set_root_pipeline(window.internal.pipeline_id);
 
-    if let Some(cursor_position) = window.state.mouse_state.cursor_pos {
-        txn.scroll(
-            ScrollLocation::Delta(LayoutVector2D::new(10.0, -10.0)),
-            // TODO: change this line as soon as the scroll events are triggering the rerender.
-            //ScrollLocation::Delta(LayoutVector2D::new(window.state.mouse_state.scroll_x as f32, window.state.mouse_state.scroll_y as f32)),
-            TypedPoint2D::new(cursor_position.x as f32, cursor_position.y as f32),
-        );
-        println!(
-            "{}, {}, {}, {}",
-            cursor_position.x as f32,
-            cursor_position.y as f32,
-            window.state.mouse_state.scroll_x as f32,
-            window.state.mouse_state.scroll_y as f32
-        );
+    let keys = window.scroll_states.0.keys().map(|k| *k).collect::<Vec<_>>();
+    for (key, value) in window.scroll_states.0.iter_mut() {
+        println!("Scroll set");
+        let (x, y) = value.get();
+        txn.scroll_node_with_id(LayoutPoint::new(x, y), *key, ScrollClamping::NoClamping);
     }
+
+    // if let Some(cursor_position) = window.state.mouse_state.cursor_pos {
+    //     txn.scroll(
+    //         ScrollLocation::Delta(LayoutVector2D::new(10.0, -10.0)),
+    //         // TODO: change this line as soon as the scroll events are triggering the rerender.
+    //         //ScrollLocation::Delta(LayoutVector2D::new(window.state.mouse_state.scroll_x as f32, window.state.mouse_state.scroll_y as f32)),
+    //         TypedPoint2D::new(cursor_position.x as f32, cursor_position.y as f32),
+    //     );
+    //     println!(
+    //         "{}, {}, {}, {}",
+    //         cursor_position.x as f32,
+    //         cursor_position.y as f32,
+    //         window.state.mouse_state.scroll_x as f32,
+    //         window.state.mouse_state.scroll_y as f32
+    //     );
+    // }
     txn.generate_frame();
 
     window.internal.api.send_transaction(window.internal.document_id, txn);

--- a/src/app.rs
+++ b/src/app.rs
@@ -893,6 +893,7 @@ fn render_on_scroll_no_layout<T: Layout>(window: &mut Window<T>) {
     let mut txn = Transaction::new();
 
     for (key, value) in window.scroll_states.0.iter_mut() {
+        println!("scrolling node {:?}", key);
         let (x, y) = value.get();
         txn.scroll_node_with_id(LayoutPoint::new(x, y), *key, ScrollClamping::ToContentBounds);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use glium::{
     },
 };
 use webrender::{PipelineInfo, api::{HitTestFlags, DevicePixel}};
-use euclid::TypedSize2D;
+use euclid::{TypedSize2D, TypedPoint2D};
 #[cfg(feature = "image_loading")]
 use image::ImageError;
 #[cfg(feature = "logging")]
@@ -826,6 +826,20 @@ fn render<T: Layout>(
     });
 
     txn.set_root_pipeline(window.internal.pipeline_id);
+
+    txn.scroll(
+        ScrollLocation::Delta(LayoutVector2D::new(10.0, 10.0)),
+        // TODO: change this line as soon as the scroll events are triggering the rerender.
+        //ScrollLocation::Delta(LayoutVector2D::new(window.state.mouse_state.scroll_x as f32, window.state.mouse_state.scroll_y as f32)),
+        TypedPoint2D::new(window.state.mouse_state.cursor_pos.unwrap().x as f32, window.state.mouse_state.cursor_pos.unwrap().y as f32),
+    );
+    println!(
+        "{}, {}, {}, {}",
+        window.state.mouse_state.cursor_pos.unwrap().x as f32,
+        window.state.mouse_state.cursor_pos.unwrap().y as f32,
+        window.state.mouse_state.scroll_x as f32,
+        window.state.mouse_state.scroll_y as f32
+    );
     txn.generate_frame();
 
     window.internal.api.send_transaction(window.internal.document_id, txn);

--- a/src/app.rs
+++ b/src/app.rs
@@ -264,6 +264,7 @@ impl<T: Layout> App<T> {
                     if scroll_x + scroll_y != 0.0 {
                         let keys = window.scroll_states.0.keys().map(|k| *k).collect::<Vec<_>>();
                         for key in &keys {
+
                             println!("Scroll");
                             window.scroll_states.scroll_node(key, scroll_x as f32, scroll_y as f32);
                         }
@@ -833,10 +834,12 @@ fn render<T: Layout>(
 
     txn.set_root_pipeline(window.internal.pipeline_id);
 
+    println!("Restoring scroll states.");
+
     let keys = window.scroll_states.0.keys().map(|k| *k).collect::<Vec<_>>();
     for (key, value) in window.scroll_states.0.iter_mut() {
-        println!("Scroll set");
         let (x, y) = value.get();
+        println!("Scroll set {}, {}", x, y);
         txn.scroll_node_with_id(LayoutPoint::new(x, y), *key, ScrollClamping::ToContentBounds);
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -837,7 +837,7 @@ fn render<T: Layout>(
     for (key, value) in window.scroll_states.0.iter_mut() {
         println!("Scroll set");
         let (x, y) = value.get();
-        txn.scroll_node_with_id(LayoutPoint::new(x, y), *key, ScrollClamping::NoClamping);
+        txn.scroll_node_with_id(LayoutPoint::new(x, y), *key, ScrollClamping::ToContentBounds);
     }
 
     // if let Some(cursor_position) = window.state.mouse_state.cursor_pos {

--- a/src/display_list.rs
+++ b/src/display_list.rs
@@ -244,8 +244,6 @@ impl<'a, T: Layout + 'a> DisplayList<'a, T> {
 
         // println!("{:?}", rects_in_rendering_order);
 
-        println!("Creating {:?} scrollable nodes.", scrollable_nodes.len());
-
         push_rectangles_into_displaylist(
             &laid_out_rectangles,
             window.internal.epoch,
@@ -487,7 +485,11 @@ fn push_rectangles_into_displaylist<'a, 'b, 'c, 'd, 'e, T: Layout>(
                 // The arena containing the actual dom maps 1:1 to the arena containing the rectangles, so we can use the NodeIds from the layouted rectangles
                 // to access the NodeData corresponding to each Rectangle in the NodeData arena.
                 // This next unwrap is fine since we are sure the looked up NodeId exists in the arena!
-                scroll_states.ensure_initialized_scroll_state(external_id);
+                scroll_states.ensure_initialized_scroll_state(
+                    external_id,
+                    inner_rect.size.width - outer_rect.size.width,
+                    inner_rect.size.height - outer_rect.size.height
+                );
                 // set the scrolling clip
                 let clip_id = referenced_mutable_content.builder.define_scroll_frame(
                     Some(external_id),

--- a/src/display_list.rs
+++ b/src/display_list.rs
@@ -472,7 +472,7 @@ fn push_rectangles_into_displaylist<'a, 'b, 'c, 'd, 'e, T: Layout>(
                 html_node: &arena[rect_idx].data.node_type,
             };
 
-            println!("Push {:?}", rect_idx);
+            // println!("Push {:?}", rect_idx);
             if let Some(&(outer_rect, inner_rect)) = scrollable_nodes.get(&rect_idx) {
                 // The unwraps on the following line must succeed, as if we have no children, we can't have a scrollable content.
                 stack.push(rect_idx.children(&arena).last().unwrap());
@@ -486,8 +486,7 @@ fn push_rectangles_into_displaylist<'a, 'b, 'c, 'd, 'e, T: Layout>(
                     ScrollSensitivity::ScriptAndInputEvents,
                 );
                 referenced_mutable_content.builder.push_clip_id(clip_id);
-                referenced_mutable_content.builder.push_clip_id(clip_id);
-                println!("Push clip")
+                // println!("Push clip")
             }
 
             displaylist_handle_rect(solved_rects[rect_idx].data, rectangle, referenced_content, referenced_mutable_content, webrender_gamma_hack_necessary);
@@ -496,7 +495,7 @@ fn push_rectangles_into_displaylist<'a, 'b, 'c, 'd, 'e, T: Layout>(
                 if child_idx == rect_idx {
                     stack.pop();
                     referenced_mutable_content.builder.pop_clip_id();
-                    println!("Pop clip");
+                    // println!("Pop clip");
                 }
             }
         }

--- a/src/display_list.rs
+++ b/src/display_list.rs
@@ -244,6 +244,8 @@ impl<'a, T: Layout + 'a> DisplayList<'a, T> {
 
         // println!("{:?}", rects_in_rendering_order);
 
+        println!("Creating {:?} scrollable nodes.", scrollable_nodes.len());
+
         push_rectangles_into_displaylist(
             &laid_out_rectangles,
             window.internal.epoch,

--- a/src/ui_solver.rs
+++ b/src/ui_solver.rs
@@ -569,7 +569,15 @@ impl Arena<$struct_name> {
         // Usually `top_level_flex_basis` is NOT 0.0, rather it's the sum of all widths in the DOM,
         // i.e. the sum of the whole DOM tree
         let top_level_flex_basis = self[NodeId::new(0)].data.min_inner_size_px;
-        self[NodeId::new(0)].data.flex_grow_px = root_width - top_level_flex_basis;
+
+        // The root node can still have some sort of max-width attached, so we need to check for that
+        let root_preferred_width = if let Some(max_width) = self[NodeId::new(0)].data.$preferred_field.max_available_space() {
+            if root_width > max_width { max_width } else { root_width }
+        } else {
+            root_width
+        };
+
+        self[NodeId::new(0)].data.flex_grow_px = root_preferred_width - top_level_flex_basis;
 
         // Keep track of the nearest relative or absolute positioned element
         let mut positioned_node_stack = vec![NodeId::new(0)];

--- a/src/window.rs
+++ b/src/window.rs
@@ -560,7 +560,7 @@ pub struct Window<T: Layout> {
 #[derive(Debug, Copy, Clone)]
 pub struct AnimationState { }
 
-pub struct ScrollStates(pub FastHashMap<ExternalScrollId, ScrollState>);
+pub(crate) struct ScrollStates(pub FastHashMap<ExternalScrollId, ScrollState>);
 
 impl ScrollStates {
     pub fn new() -> ScrollStates {
@@ -583,9 +583,7 @@ impl ScrollStates {
     }
 
     pub(crate) fn ensure_initialized_scroll_state(&mut self, scroll_id: ExternalScrollId, overflow_x: f32, overflow_y: f32) {
-        if !self.0.contains_key(&scroll_id) {
-            self.0.insert(scroll_id, ScrollState::new(overflow_x, overflow_y));
-        }
+        self.0.entry(scroll_id).or_insert_with(|| ScrollState::new(overflow_x, overflow_y));
     }
 
     /// Removes all scroll states that weren't used in the last frame


### PR DESCRIPTION
Scrolling works in a very basic fashion.
+ Scroll speed is fixed to 3 * scroll_delta [px]. This should later be defined by the system settings.
+ Every element is scrolled not just the hovered one. Code to check for the ones hit by the mouse is in place but not active since something with hit-testing is broken (not related to scrolling).
+ No scrollbars are displayed.
+ Every overflowing element has scroll! CSS proeprties are not yet considered. This can only be done after hit-testing is fixed and activated!