### PR TITLE
Fix missing fonts on startup

### DIFF
--- a/azul/src/display_list.rs
+++ b/azul/src/display_list.rs
@@ -228,6 +228,9 @@ impl<'a, T: Layout + 'a> DisplayList<'a, T> {
         let node_hierarchy = &arena.node_layout;
         let node_data = &arena.node_data;
 
+        // Upload image and font resources
+        Self::update_resources(&window.internal.api, app_resources, &mut resource_updates);
+
         let (laid_out_rectangles, node_depths, word_cache) = do_the_layout(
             node_hierarchy,
             node_data,
@@ -249,9 +252,6 @@ impl<'a, T: Layout + 'a> DisplayList<'a, T> {
 
         let LogicalSize { width, height } = window.state.size.dimensions;
         let mut builder = DisplayListBuilder::with_capacity(window.internal.pipeline_id, TypedSize2D::new(width as f32, height as f32), self.rectangles.len());
-
-        // Upload image and font resources
-        Self::update_resources(&window.internal.api, app_resources, &mut resource_updates);
 
         let rects_in_rendering_order = determine_rendering_order(node_hierarchy, &self.rectangles, &laid_out_rectangles);
 

--- a/azul/src/error.rs
+++ b/azul/src/error.rs
@@ -1,5 +1,4 @@
 pub use app::RuntimeError;
-#[cfg(debug_assertions)]
 pub use font::FontError;
 #[cfg(feature = "image_loading")]
 pub use image::ImageError;

--- a/azul/src/lib.rs
+++ b/azul/src/lib.rs
@@ -211,6 +211,7 @@ pub mod prelude {
     pub use default_callbacks::StackCheckedPointer;
     pub use text_layout::TextLayoutOptions;
 
+    #[cfg(any(feature = "css_parser", feature = "native-style"))]
     pub use css;
 
     #[cfg(feature = "logging")]


### PR DESCRIPTION
This fixes #65 by uploading new fonts to the GPU before the initial layout of the DOM.

I also added in some fixes for compile failures that were hidden behind feature gates.