### PR TITLE
Refactor system font loading

### DIFF
--- a/azul-css-parser/src/css_parser.rs
+++ b/azul-css-parser/src/css_parser.rs
@@ -1786,9 +1786,9 @@ pub fn parse_style_font_family<'a>(input: &'a str) -> Result<StyleFontFamily, Cs
 
         if double_quote_iter.next().is_some() || single_quote_iter.next().is_some() {
             let stripped_font = strip_quotes(font)?;
-            fonts.push(FontId::ExternalFont(stripped_font.0.into()));
+            fonts.push(FontId(stripped_font.0.into()));
         } else {
-            fonts.push(FontId::BuiltinFont(font.into()));
+            fonts.push(FontId(font.into()));
         }
     }
 
@@ -2465,8 +2465,8 @@ mod css_tests {
     fn test_parse_style_font_family_1() {
         assert_eq!(parse_style_font_family("\"Webly Sleeky UI\", monospace"), Ok(StyleFontFamily {
             fonts: vec![
-                FontId::ExternalFont("Webly Sleeky UI".into()),
-                FontId::BuiltinFont("monospace".into()),
+                FontId("Webly Sleeky UI".into()),
+                FontId("monospace".into()),
             ]
         }));
     }
@@ -2475,7 +2475,7 @@ mod css_tests {
     fn test_parse_style_font_family_2() {
         assert_eq!(parse_style_font_family("'Webly Sleeky UI'"), Ok(StyleFontFamily {
             fonts: vec![
-                FontId::ExternalFont("Webly Sleeky UI".into()),
+                FontId("Webly Sleeky UI".into()),
             ]
         }));
     }

--- a/azul-css/src/css_properties.rs
+++ b/azul-css/src/css_properties.rs
@@ -1207,8 +1207,6 @@ pub struct StyleFontFamily {
     pub fonts: Vec<FontId>
 }
 
+/// Specifies a unique identifier for a font, similar to a CssImageId.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub enum FontId {
-    BuiltinFont(String),
-    ExternalFont(String),
-}
+pub struct FontId(pub String);

--- a/azul/Cargo.toml
+++ b/azul/Cargo.toml
@@ -28,7 +28,7 @@ unicode-normalization   = { version = "0.1.5",                default-features =
 lazy_static             = { version = "1",                    default-features = false }
 tinyfiledialogs         = { version = "3.3.5",                default-features = false }
 clipboard2              = { version = "0.1.0",                default-features = false }
-font-loader             = { version = "0.7.0",                default-features = false }
+font-loader             = { version = "0.7.0",                default-features = false, optional = true }
 azul-native-style       = { version = "0.1.0",                path = "../azul-native-style", optional = true }
 azul-css-parser         = { version = "0.1.0",                path = "../azul-css-parser",   optional = true }
 serde                   = { version = "1",                    default-features = false, optional = true }
@@ -59,7 +59,10 @@ default = [
     "image_loading",
     "native-style",
     "css-parser",
+    "system_fonts",
 ]
+# Enables scanning installed fonts on the system for use in an application
+system_fonts = ["font-loader"]
 # Enable this feature to enable crash logging & reporting.
 # Azul will insert custom panic handlers to pop up a message and log
 # crashes to an "error.log" file, see AppConfig for more details

--- a/azul/src/app.rs
+++ b/azul/src/app.rs
@@ -213,6 +213,7 @@ impl<T: Layout> App<T> {
     /// ```
     pub fn run(mut self, window: Window<T>) -> Result<T, RuntimeError<T>>
     {
+        #[cfg(feature="system_fonts")]
         self.load_system_fonts(window.style.required_fonts());
         // Apps need to have at least one window open
         self.push_window(window);
@@ -376,6 +377,7 @@ impl<T: Layout> App<T> {
 
                 // It's okay to call this multiple times with the same font id; nothing will happen
                 // if a font with the same id has already been loaded
+                #[cfg(feature="system_fonts")]
                 self.load_system_fonts(referenced_fonts);
             }
 
@@ -545,6 +547,7 @@ impl<T: Layout> App<T> {
     }
 
     /// Uses system fonts to load any specified fonts that have not already been added as resources
+    #[cfg(feature="system_fonts")]
     fn load_system_fonts(&mut self, fonts: Vec<FontId>) {
         for font_id in fonts {
             if !self.has_font(&font_id) {

--- a/azul/src/app_resources.rs
+++ b/azul/src/app_resources.rs
@@ -159,6 +159,7 @@ impl AppResources {
     }
 
     /// Search for a font installed on the user's computer, validate and return it
+    #[cfg(feature="system_fonts")]
     pub(crate) fn get_system_font(id: String) -> Option<(::rusttype::Font<'static>, Vec<u8>)>
     {
         use font_loader::system_fonts::{self, FontPropertyBuilder};

--- a/azul/src/app_state.rs
+++ b/azul/src/app_state.rs
@@ -2,7 +2,6 @@ use std::{
     io::Read,
     collections::hash_map::Entry::*,
     sync::{Arc, Mutex},
-    rc::Rc,
 };
 #[cfg(feature = "image_loading")]
 use image::ImageError;
@@ -191,7 +190,7 @@ impl<T: Layout> AppState<T> {
         self.resources.has_font(id)
     }
 
-    pub fn get_font(&self, id: &FontId) -> Option<(Rc<Font<'static>>, Rc<Vec<u8>>)> {
+    pub fn get_font(&self, id: &FontId) -> Option<(Font<'static>, Vec<u8>)> {
         self.resources.get_font(id)
     }
 

--- a/azul/src/app_state.rs
+++ b/azul/src/app_state.rs
@@ -173,7 +173,7 @@ impl<T: Layout> AppState<T> {
     ///
     /// fn my_callback(app_state: &mut AppState<MyAppData>, event: WindowEvent<MyAppData>) -> UpdateScreen {
     ///     /// Here you can add your font at runtime to the app_state
-    ///     app_state.add_font(FontId::ExternalFont("Webly Sleeky UI".into()), &mut TEST_FONT).unwrap();
+    ///     app_state.add_font(FontId("Webly Sleeky UI".into()), &mut TEST_FONT).unwrap();
     ///     UpdateScreen::DontRedraw
     /// }
     /// ```
@@ -183,7 +183,7 @@ impl<T: Layout> AppState<T> {
         self.resources.add_font(id, data)
     }
 
-    /// Checks if a font is currently registered and ready-to-use
+    /// Checks if a font is currently registered and ready-to-use, or pending registration
     pub fn has_font(&self, id: &FontId)
         -> bool
     {

--- a/azul/src/display_list.rs
+++ b/azul/src/display_list.rs
@@ -174,8 +174,7 @@ impl<'a, T: Layout + 'a> DisplayList<'a, T> {
                 FontResourceUpdate::Upload(id, font, bytes) => {
                     let key = api.generate_font_key();
                     resource_updates.push(ResourceUpdate::AddFont(AddFont::Raw(key, bytes.clone(), 0))); // TODO: use the index better?
-                    let mut borrow_mut = app_resources.font_data.borrow_mut();
-                    borrow_mut.insert(id, (Rc::new(font), Rc::new(bytes), Rc::new(RefCell::new(key))));
+                    app_resources.font_data.insert(id, (Rc::new(font), Rc::new(bytes), Rc::new(RefCell::new(key))));
                 },
                 // Delete the complete font. Maybe a more granular option to
                 // keep the font data in memory should be added later
@@ -190,7 +189,7 @@ impl<'a, T: Layout + 'a> DisplayList<'a, T> {
                         resource_updates.push(ResourceUpdate::DeleteFont(font_key.clone()));
                         app_resources.fonts.remove(&font_key);
                     };
-                    app_resources.font_data.borrow_mut().remove(&id);
+                    app_resources.font_data.remove(&id);
                 }
             }
         }

--- a/azul/src/dom.rs
+++ b/azul/src/dom.rs
@@ -13,7 +13,7 @@ use {
     ui_state::UiState,
     FastHashMap,
     window::{WindowEvent, WindowInfo},
-    images::{ImageId, ImageState},
+    images::{ImageId, ImageInfo},
     text_cache::TextId,
     traits::Layout,
     app_state::AppState,
@@ -296,7 +296,7 @@ impl<T: Layout> NodeType<T> {
 
     /// Returns the preferred width, for example for an image, that would be the
     /// original width (an image always wants to take up the original space)
-    pub(crate) fn get_preferred_width(&self, image_cache: &FastHashMap<ImageId, ImageState>) -> Option<f32> {
+    pub(crate) fn get_preferred_width(&self, image_cache: &FastHashMap<ImageId, ImageInfo>) -> Option<f32> {
         use self::NodeType::*;
         match self {
             Image(i) => image_cache.get(i).and_then(|image_state| Some(image_state.get_dimensions().0)),
@@ -309,7 +309,7 @@ impl<T: Layout> NodeType<T> {
     pub(crate) fn get_preferred_height_based_on_width(
         &self,
         div_width: TextSizePx,
-        image_cache: &FastHashMap<ImageId, ImageState>,
+        image_cache: &FastHashMap<ImageId, ImageInfo>,
         words: Option<&Words>,
         font_metrics: Option<FontMetrics>,
     ) -> Option<TextSizePx>

--- a/azul/src/images.rs
+++ b/azul/src/images.rs
@@ -50,26 +50,18 @@ pub(crate) struct ImageInfo {
     pub(crate) descriptor: ImageDescriptor,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) enum ImageState {
-    // resource is available for the renderer
-    Uploaded(ImageInfo),
-    // image is loaded & decoded, but not yet available
-    ReadyForUpload((ImageData, ImageDescriptor)),
-    // Image is about to get deleted in the next frame
-    AboutToBeDeleted((Option<ImageKey>, ImageDescriptor)),
-}
-
-impl ImageState {
+impl ImageInfo {
     /// Returns the original dimensions of the image
     pub fn get_dimensions(&self) -> (f32, f32) {
-        use self::ImageState::*;
-        match self {
-            Uploaded(ImageInfo { descriptor, .. }) |
-            ReadyForUpload((_, descriptor)) |
-            AboutToBeDeleted((_, descriptor)) => (descriptor.size.width as f32, descriptor.size.height as f32)
-        }
+        (self.descriptor.size.width as f32, self.descriptor.size.height as f32)
     }
+}
+
+pub(crate) enum ImageResourceUpdate {
+    /// Loaded & decoded image texture should be uploaded to the rendering engine
+    Upload(ImageId, ImageData, ImageDescriptor),
+    /// Image should be deleted
+    Delete(ImageId, Option<ImageKey>, ImageDescriptor),
 }
 
 impl ImageType {

--- a/azul/src/lib.rs
+++ b/azul/src/lib.rs
@@ -83,8 +83,9 @@ extern crate app_units;
 extern crate unicode_normalization;
 extern crate tinyfiledialogs;
 extern crate clipboard2;
-extern crate font_loader;
 
+#[cfg(feature="system_fonts")]
+extern crate font_loader;
 #[cfg(feature = "logging")]
 #[cfg_attr(feature = "logging", macro_use)]
 extern crate log;

--- a/azul/src/widgets/svg.rs
+++ b/azul/src/widgets/svg.rs
@@ -1248,7 +1248,7 @@ impl VectorizedFont {
         use font::rusttype_load_font;
 
         let file_contents = fs::read(path).ok()?;
-        let font = rusttype_load_font(file_contents, None).ok()?.0;
+        let font = rusttype_load_font(&file_contents, None).ok()?;
         Some(Self::from_font(&font))
     }
 }

--- a/azul/src/widgets/svg.rs
+++ b/azul/src/widgets/svg.rs
@@ -1373,7 +1373,7 @@ impl VectorizedFontCache {
 
     pub fn get_font(&self, id: &FontId, app_resources: &AppResources) -> Option<Arc<VectorizedFont>> {
         self.vectorized_fonts.lock().unwrap().entry(id.clone())
-            .or_insert_with(|| Arc::new(VectorizedFont::from_font(&*app_resources.get_font(&id).unwrap().0)));
+            .or_insert_with(|| Arc::new(VectorizedFont::from_font(&app_resources.get_font(&id).unwrap().0)));
         self.vectorized_fonts.lock().unwrap().get(&id).and_then(|font| Some(font.clone()))
     }
 

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -238,7 +238,7 @@ fn main() {
     macro_rules! CSS_PATH { () => (concat!(env!("CARGO_MANIFEST_DIR"), "/../examples/calculator.css")) }
 
     let mut app = App::new(Calculator::default(), AppConfig::default());
-    app.add_font(FontId::ExternalFont("KoHo-Light".into()), &mut FONT.clone()).unwrap();
+    app.add_font(FontId("KoHo-Light".into()), &mut FONT.clone()).unwrap();
     let css = css::override_native(include_str!(CSS_PATH!())).unwrap();
     let window = Window::new(WindowCreateOptions::default(), css).unwrap();
     app.run(window).unwrap();

--- a/examples/dragger.rs
+++ b/examples/dragger.rs
@@ -19,7 +19,7 @@ impl Layout for DragMeApp {
 
         // Set the width of the dragger on the red element
         if let Some(w) = self.width {
-            left.add_style_override("drag_width", CssProperty::Width(LayoutWidth::px(w)));
+            left.add_css_override("drag_width", CssProperty::Width(LayoutWidth::px(w)));
         }
 
         let right = Dom::new(NodeType::Div).with_id("orange");


### PR DESCRIPTION
Fixes #65 for real this time -- I tried it out on the list, scroll_list, calculator, and game_of_life examples in both debug and release mode.

Essentially, all the font data in `app_resources.rs` was wrapped in `RefCell<Rc<_>>`, which made it really hard to reason about ownership. Consequently, system fonts would be loaded for the first time from an immutable binding in the render loop. This PR makes azul scan through the provided `Css` at startup or on hot-reload events and attempt to load system fonts as necessary.

I removed the distinction between "builtin" and "external" fonts, since the difference was really nuanced in the first place. The datatypes were the same, it just boiled down to semantics of "attempt to load this from the system" or "don't", which can already be achieved by using `app.add_font()` anyways. The "builtin" naming also seems to imply they come packaged with azul, which can be confusing. Instead, all `FontId`s are now just identifiers like `CssImageId`, and I added the `system_fonts` feature (enabled by default) that makes azul attempt to load fonts from the system if they're not already available as a resource.

While making this PR, I came up with a few other considerations for the future, which should be compatible with the new model:

* It should eventually be possible to load resources by callback at runtime, for e.g. loading new images in graphical design apps or fonts in WYSIWYG text editors.

* It should be possible to embed resources alongside rules in the `Css`. Background textures and fonts are definitely a part of an application's style, and the CSS standard supports the same concept with `@font-face` and `src: data(...)`.