### PR TITLE
Fix invisible font on macOS

### DIFF
--- a/azul-native-style/src/styles/native_macos.css
+++ b/azul-native-style/src/styles/native_macos.css
@@ -1,6 +1,6 @@
 * {
     font-size: 12px;
-    font-family: sans-serif;
+    font-family: Helvetica;
     color: #4c4c4c;
 }
 


### PR DESCRIPTION
On my machine running macOS Mojave, the text in all provided examples is invisible. Changing the font in the CSS styling from sans-serif to different fonts, such as Arial, fixes this, and Helvetica seems a particularly appropriate default for macOS.