### PR TITLE
Implement background-repeat

### DIFF
--- a/azul-css-parser/src/css_parser.rs
+++ b/azul-css-parser/src/css_parser.rs
@@ -11,7 +11,7 @@ use azul_css::{
     LayoutMaxHeight, LayoutMinHeight, LayoutHeight, LayoutMaxWidth, LayoutMinWidth, LayoutWidth,
     StyleBorderRadius, PixelValue, PercentageValue, FloatValue,
     ColorU, LayoutMargin, StyleLetterSpacing, StyleTextColor, StyleBackground, StyleBoxShadow,
-    GradientStopPre, RadialGradient, StyleBackgroundColor, StyleBackgroundSize,
+    GradientStopPre, RadialGradient, StyleBackgroundColor, StyleBackgroundSize, StyleBackgroundRepeat,
     DirectionCorner, StyleBorder, Direction, CssImageId, LinearGradient,
     BoxShadowPreDisplayItem, BorderStyle, LayoutPadding, StyleBorderSide, BorderRadius, PixelSize,
 
@@ -64,6 +64,7 @@ pub fn parse_key_value_pair<'a>(key: CssPropertyType, value: &'a str) -> Result<
         BorderRadius     => Ok(parse_style_border_radius(value)?.into()),
         BackgroundColor  => Ok(parse_style_background_color(value)?.into()),
         BackgroundSize   => Ok(parse_style_background_size(value)?.into()),
+        BackgroundRepeat => Ok(parse_style_background_repeat(value)?.into()),
         TextColor        => Ok(parse_style_text_color(value)?.into()),
         Background       => Ok(parse_style_background(value)?.into()),
         FontSize         => Ok(parse_style_font_size(value)?.into()),
@@ -1627,6 +1628,8 @@ pub struct RectStyle {
     pub background_color: Option<StyleBackgroundColor>,
     /// Background size of this rectangle
     pub background_size: Option<StyleBackgroundSize>,
+    /// Background repeat of this rectangle
+    pub background_repeat: Option<StyleBackgroundRepeat>,
     /// Shadow color
     pub box_shadow: Option<StyleBoxShadow>,
     /// Gradient (location) + stops
@@ -1817,6 +1820,12 @@ multi_type_parser!(parse_style_cursor, StyleCursor,
 multi_type_parser!(parse_style_background_size, StyleBackgroundSize,
                     ["contain", Contain],
                     ["cover", Cover]);
+
+multi_type_parser!(parse_style_background_repeat, StyleBackgroundRepeat,
+                    ["no-repeat", NoRepeat],
+                    ["repeat", Repeat],
+                    ["repeat-x", RepeatX],
+                    ["repeat-y", RepeatY]);
 
 multi_type_parser!(parse_layout_direction, LayoutDirection,
                     ["row", Row],

--- a/azul-css/src/css_properties.rs
+++ b/azul-css/src/css_properties.rs
@@ -196,10 +196,11 @@ macro_rules! impl_pixel_value {($struct:ident) => (
     }
 )}
 
-pub const CSS_PROPERTY_KEY_MAP: [(CssPropertyType, &'static str);52] = [
+pub const CSS_PROPERTY_KEY_MAP: [(CssPropertyType, &'static str);53] = [
     (CssPropertyType::BorderRadius,     "border-radius"),
     (CssPropertyType::BackgroundColor,  "background-color"),
     (CssPropertyType::BackgroundSize,   "background-size"),
+    (CssPropertyType::BackgroundRepeat, "background-repeat"),
     (CssPropertyType::TextColor,        "color"),
     (CssPropertyType::Background,       "background"),
     (CssPropertyType::FontSize,         "font-size"),
@@ -263,6 +264,7 @@ pub enum CssPropertyType {
     BorderRadius,
     BackgroundColor,
     BackgroundSize,
+    BackgroundRepeat,
     TextColor,
     Background,
     FontSize,
@@ -367,6 +369,7 @@ impl CssPropertyType {
             | BorderRadius
             | BackgroundColor
             | BackgroundSize
+            | BackgroundRepeat
             | TextColor
             | Background
             | TextAlign
@@ -394,6 +397,7 @@ pub enum CssProperty {
     BorderRadius(StyleBorderRadius),
     BackgroundColor(StyleBackgroundColor),
     BackgroundSize(StyleBackgroundSize),
+    BackgroundRepeat(StyleBackgroundRepeat),
     TextColor(StyleTextColor),
     Border(StyleBorder),
     Background(StyleBackground),
@@ -433,6 +437,7 @@ impl CssProperty {
             CssProperty::BorderRadius(_) => CssPropertyType::BorderRadius,
             CssProperty::BackgroundColor(_) => CssPropertyType::BackgroundColor,
             CssProperty::BackgroundSize(_) => CssPropertyType::BackgroundSize,
+            CssProperty::BackgroundRepeat(_) => CssPropertyType::BackgroundRepeat,
             CssProperty::TextColor(_) => CssPropertyType::TextColor,
             CssProperty::Border(_) => CssPropertyType::Border,
             CssProperty::Background(_) => CssPropertyType::Background,
@@ -479,6 +484,7 @@ impl_from!(StyleLineHeight, CssProperty::LineHeight);
 impl_from!(StyleLetterSpacing, CssProperty::LetterSpacing);
 impl_from!(StyleBackgroundColor, CssProperty::BackgroundColor);
 impl_from!(StyleBackgroundSize, CssProperty::BackgroundSize);
+impl_from!(StyleBackgroundRepeat, CssProperty::BackgroundRepeat);
 impl_from!(StyleTextColor, CssProperty::TextColor);
 impl_from!(StyleCursor, CssProperty::Cursor);
 
@@ -629,6 +635,15 @@ impl Default for StyleBackgroundColor {
 pub enum StyleBackgroundSize {
     Contain,
     Cover
+}
+
+/// Represents a `background-repeat` attribute
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum StyleBackgroundRepeat {
+    NoRepeat,
+    Repeat,
+    RepeatX,
+    RepeatY,
 }
 
 /// Represents a `color` attribute
@@ -1351,6 +1366,8 @@ pub struct RectStyle {
     pub background_color: Option<StyleBackgroundColor>,
     /// Background size of this rectangle
     pub background_size: Option<StyleBackgroundSize>,
+    /// Background repetition
+    pub background_repeat: Option<StyleBackgroundRepeat>,
     /// Shadow color
     pub box_shadow: Option<StyleBoxShadow>,
     /// Gradient (location) + stops

--- a/azul/src/display_list.rs
+++ b/azul/src/display_list.rs
@@ -24,9 +24,9 @@ use azul_css::{
     Css, StyleTextAlignmentHorz, LayoutPosition,CssProperty, LayoutOverflow,
     StyleFontSize, StyleBorderRadius, PixelValue, FloatValue, LayoutMargin,
     StyleTextColor, StyleBackground, StyleBoxShadow, StyleBackgroundColor,
-    StyleBackgroundSize, StyleBorder, BoxShadowPreDisplayItem, LayoutPadding, SizeMetric,
-    BoxShadowClipMode, FontId, StyleTextAlignmentVert, RectStyle, RectLayout,
-    ColorU as StyleColorU
+    StyleBackgroundSize, StyleBackgroundRepeat, StyleBorder, BoxShadowPreDisplayItem,
+    LayoutPadding, SizeMetric, BoxShadowClipMode, FontId, StyleTextAlignmentVert,
+    RectStyle, RectLayout, ColorU as StyleColorU
 };
 use {
     FastHashMap,
@@ -916,7 +916,8 @@ fn displaylist_handle_rect<'a,'b,'c,'d,'e,'f,'g, T: Layout>(
             &bounds,
             referenced_mutable_content.builder,
             bg,
-            rect.style.background_size,
+            &rect.style.background_size,
+            &rect.style.background_repeat,
             &referenced_mutable_content.app_resources);
     }
 
@@ -1691,7 +1692,8 @@ fn push_background(
     bounds: &TypedRect<f32, LayoutPixel>,
     builder: &mut DisplayListBuilder,
     background: &StyleBackground,
-    background_size: Option<StyleBackgroundSize>,
+    background_size: &Option<StyleBackgroundSize>,
+    background_repeat: &Option<StyleBackgroundRepeat>,
     app_resources: &AppResources)
 {
     use azul_css::StyleBackground::*;
@@ -1752,7 +1754,18 @@ fn push_background(
                     None => TypedSize2D::new(image_dimensions.0, image_dimensions.1)
                 };
 
-                push_image(info, builder, app_resources, image_id, size);
+                let info = if let Some(repeat) = background_repeat {
+                    match repeat {
+                        StyleBackgroundRepeat::NoRepeat => LayoutPrimitiveInfo::with_clip_rect(info.rect, TypedRect::from_size(size)),
+                        StyleBackgroundRepeat::Repeat => *info,
+                        StyleBackgroundRepeat::RepeatX => LayoutPrimitiveInfo::with_clip_rect(info.rect, TypedRect::from_size(TypedSize2D::new(info.rect.size.width, size.height))),
+                        StyleBackgroundRepeat::RepeatY => LayoutPrimitiveInfo::with_clip_rect(info.rect, TypedRect::from_size(TypedSize2D::new(size.width, info.rect.size.height))),
+                    }
+                } else {
+                    *info
+                };
+
+                push_image(&info, builder, app_resources, image_id, size);
             }
         },
         NoBackground => { },
@@ -1764,7 +1777,7 @@ struct Ratio {
     height: f32
 }
 
-fn calculate_background_size(bg_size: StyleBackgroundSize, info: &PrimitiveInfo<LayoutPixel>, image_dimensions: &(f32, f32))
+fn calculate_background_size(bg_size: &StyleBackgroundSize, info: &PrimitiveInfo<LayoutPixel>, image_dimensions: &(f32, f32))
 -> TypedSize2D<f32, LayoutPixel>
 {
     let original_ratios = Ratio {
@@ -1803,7 +1816,7 @@ fn push_image(
             // This leads to lighter images, but that's just how things are right now
 
             builder.push_image(
-                    &info,
+                    info,
                     size,
                     LayoutSize::zero(),
                     ImageRendering::Auto,
@@ -1960,7 +1973,8 @@ fn populate_css_properties(
         match property {
             BorderRadius(b)     => { rect.style.border_radius = Some(*b);                   },
             BackgroundColor(c)  => { rect.style.background_color = Some(*c);                },
-            BackgroundSize(c)   => { rect.style.background_size = Some(*c);                 },
+            BackgroundSize(s)   => { rect.style.background_size = Some(*s);                 },
+            BackgroundRepeat(r) => { rect.style.background_repeat = Some(*r);               },
             TextColor(t)        => { rect.style.font_color = Some(*t);                      },
             Border(b)           => { StyleBorder::merge(&mut rect.style.border, &b);        },
             Background(b)       => { rect.style.background = Some(b.clone());               },


### PR DESCRIPTION
The goal of this PR is to implement single value `background-repeat` for `no-repeat`, `repeat-x`, and `repeat-y`.
A subsequent PR will implement `space` and `round`, as their implementations are slightly more involved.

This was implemented by using LayoutPrimitiveInfo's clip_rect functionality.
If `background-repeat: no-repeat;` is present in the CSS, clip_rect is set to the size of the image.

I also changed the `push_background` function so that it receives a `&Option<StyleBackgroundSize>`, as mentioned in https://github.com/maps4print/azul/pull/89#issuecomment-452841096.

## Tasks
- [x] Implement `no-repeat`
- [x] Implement `repeat`
- [x] Implement `repeat-x`
- [x] Implement `repeat-y`

