### PR TITLE
Added basic cursor to TextInput

### DIFF
--- a/azul-native-style/src/styles/native_linux.css
+++ b/azul-native-style/src/styles/native_linux.css
@@ -36,6 +36,15 @@
     border: 1px solid #4286f4;
 }
 
+.__azul-native-input-text-cursor {
+    position: absolute;
+    background-color: black;
+    width: 1.5px;
+    height: [[ height | auto ]];
+    left: [[ left | 0px ]];
+    top: [[ top | 0px ]];
+}
+
 .__azul-native-input-text-label {
 
 }

--- a/azul-native-style/src/styles/native_macos.css
+++ b/azul-native-style/src/styles/native_macos.css
@@ -37,6 +37,15 @@
     border: 1px solid #4286f4;
 }
 
+.__azul-native-input-text-cursor {
+    position: absolute;
+    background-color: black;
+    width: 1.5px;
+    height: [[ height | auto ]];
+    left: [[ left | 0px ]];
+    top: [[ top | 0px ]];
+}
+
 .__azul-native-input-text-label {
 
 }

--- a/azul-native-style/src/styles/native_windows.css
+++ b/azul-native-style/src/styles/native_windows.css
@@ -48,6 +48,15 @@
     border: 1px solid #4286f4;
 }
 
+.__azul-native-input-text-cursor {
+    position: absolute;
+    background-color: black;
+    width: 1.5px;
+    height: [[ height | auto ]];
+    left: [[ left | 0px ]];
+    top: [[ top | 0px ]];
+}
+
 .__azul-native-input-text-label {
 
 }

--- a/azul/src/app.rs
+++ b/azul/src/app.rs
@@ -959,7 +959,7 @@ fn update_display_list<T>(
 
     // NOTE: layout_result contains all words, text information, etc.
     // - very important for selection!
-    let (builder, scrolled_nodes, _layout_result) = display_list.into_display_list_builder(
+    let (builder, scrolled_nodes, layout_result) = display_list.into_display_list_builder(
         app_data,
         window,
         fake_window,
@@ -982,6 +982,7 @@ fn update_display_list<T>(
     );
 
     app_resources.fake_display.render_api.send_transaction(window.internal.document_id, txn);
+    fake_window.state.last_layout_result = Some(layout_result);
 }
 
 /// Scroll all nodes in the ScrollStates to their correct position and insert

--- a/azul/src/callbacks.rs
+++ b/azul/src/callbacks.rs
@@ -392,9 +392,19 @@ impl<'a, T: 'a> CallbackInfo<'a, T> {
         self.get_node(node_id)?.parent
     }
 
+    /// Returns 'NodeId' of children
+    pub fn children(&self, node_id: NodeId) -> Vec<NodeId> {
+        node_id.children(&self.ui_state.dom.arena.node_layout).collect()
+    }
+
     /// Returns the parent of the current target or None if the target is the root node.
     pub fn target_parent(&self) -> Option<NodeId> {
         self.parent(self.hit_dom_node)
+    }
+
+    /// Returns the NodeIds of children of the current target
+    pub fn target_children(&self) -> Vec<NodeId> {
+        self.children(self.hit_dom_node)
     }
 
     /// Checks whether the target of the CallbackInfo has a certain node type

--- a/azul/src/text_layout.rs
+++ b/azul/src/text_layout.rs
@@ -15,10 +15,10 @@ pub type IndexOfLineBreak = usize;
 pub type RemainingSpaceToRight = f32;
 pub type LineBreaks = Vec<(GlyphIndex, RemainingSpaceToRight)>;
 
-const DEFAULT_LINE_HEIGHT: f32 = 1.0;
-const DEFAULT_WORD_SPACING: f32 = 1.0;
-const DEFAULT_LETTER_SPACING: f32 = 0.0;
-const DEFAULT_TAB_WIDTH: f32 = 4.0;
+pub const DEFAULT_LINE_HEIGHT: f32 = 1.0;
+pub const DEFAULT_WORD_SPACING: f32 = 1.0;
+pub const DEFAULT_LETTER_SPACING: f32 = 0.0;
+pub const DEFAULT_TAB_WIDTH: f32 = 4.0;
 
 /// Text broken up into `Tab`, `Word()`, `Return` characters
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/azul/src/widgets/text_input.rs
+++ b/azul/src/widgets/text_input.rs
@@ -4,6 +4,8 @@ use std::ops::Range;
 use {
     callbacks::{UpdateScreen, Redraw, DontRedraw},
     dom::{Dom, EventFilter, FocusEventFilter, TabIndex},
+    azul_css::{ CssProperty, LayoutLeft, LayoutTop },
+    text_layout::{ DEFAULT_WORD_SPACING, DEFAULT_TAB_WIDTH, DEFAULT_LINE_HEIGHT },
     window::FakeWindow,
     prelude::VirtualKeyCode,
     callbacks::{CallbackInfo, StackCheckedPointer, DefaultCallback, DefaultCallbackId},
@@ -15,11 +17,12 @@ pub struct TextInput {
     on_text_input_callback: Option<(DefaultCallbackId, DefaultCallbackId)>,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TextInputState {
     pub text: String,
     pub selection: Option<Selection>,
     pub cursor: usize,
+    pub cursor_position: Option<(f32,f32)>
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -34,6 +37,7 @@ impl Default for TextInputState {
             text: String::new(),
             selection: None,
             cursor: 0,
+            cursor_position: None
         }
     }
 }
@@ -46,6 +50,7 @@ impl TextInputState {
             text: input_str,
             selection: None,
             cursor: len,
+            cursor_position: None
         }
     }
 }
@@ -81,8 +86,17 @@ impl TextInput {
             parent_div.add_default_callback_id(EventFilter::Focus(FocusEventFilter::VirtualKeyDown), vk_callback);
         }
 
-        let label = Dom::label(field.text.clone()).with_class("__azul-native-input-text-label");
-        parent_div.with_child(label)
+        parent_div = parent_div.with_child(Dom::label(field.text.clone())
+                               .with_class("__azul-native-input-text-label"));
+
+        if let Some((x,y)) = field.cursor_position {
+            parent_div = parent_div.with_child(Dom::div()
+                                   .with_class("__azul-native-input-text-cursor")
+                                   .with_css_override("left",CssProperty::Left(LayoutLeft::px(x)))
+                                   .with_css_override("top",CssProperty::Top(LayoutTop::px(y))));
+        }
+
+        parent_div
     }
 }
 
@@ -96,9 +110,73 @@ impl TextInputState {
         unsafe { data.invoke_mut(Self::on_text_input, app_state_no_data, window_event) }
     }
 
+    pub fn update_cursor_position<T>(&mut self, app_state_no_data: &mut AppStateNoData<T>, event: &mut CallbackInfo<T>) {
+        use text_layout::WordType;
+
+        // set to None so that it won't be displayed if the positioning fails.
+        self.cursor_position = None;
+
+        let children = event.target_children();
+        if children.len() > 0 {
+            let maybe_layout = &app_state_no_data.windows[event.window_id].state.last_layout_result;
+            let maybe_node   = children.first(); // assuming the display label is the first child
+
+            if let (Some(id),Some(layout)) = (maybe_node,maybe_layout) {
+
+                let maybe_words            = layout.word_cache.get(&id);
+                let maybe_positioned_words = layout.positioned_word_cache.get(&id);
+                let maybe_scaled_words     = layout.scaled_words.get(&id);
+
+                if let (Some(words),Some((scaled,_)),Some((positioned,_))) = (maybe_words,maybe_scaled_words,maybe_positioned_words) {
+
+                    let mut scaled_iter = scaled.items.iter();
+
+                    let space_size_px   = scaled.space_advance_px;
+                    let font_size_px    = scaled.font_size_px;
+
+                    let word_spacing_px = space_size_px * positioned.text_layout_options.word_spacing.unwrap_or(DEFAULT_WORD_SPACING);
+                    let line_height_px  = space_size_px * positioned.text_layout_options.line_height.unwrap_or(DEFAULT_LINE_HEIGHT);
+                    let tab_spacing_px  = word_spacing_px + space_size_px * positioned.text_layout_options.tab_width.unwrap_or(DEFAULT_TAB_WIDTH);
+
+                    let mut x = 0.0;
+                    let mut y = 0.0;
+
+                    let line_breaks = &positioned.line_breaks;
+                    let mut glyphs = vec![];
+
+                    for w in words.items.iter() {
+                        match w.word_type {
+                            WordType::Word => {
+                                if let Some(ref sw) = scaled_iter.next() {
+                                    for gp in sw.glyph_positions.iter() {
+                                        glyphs.push((gp.x_advance as f32)/128.0);
+                                    }
+                                }
+                            },
+                            WordType::Tab => { glyphs.push(tab_spacing_px); },
+                            WordType::Space => { glyphs.push(word_spacing_px); },
+                            _ => ()
+                        }
+                    }
+
+                    x = glyphs.iter().take(self.cursor)
+                                     .fold(0.0,|a,o| a + o);
+
+                    for line_break in line_breaks.iter().take(line_breaks.len().saturating_sub(1)) {
+                        x -= line_break.1;
+                        y += line_height_px + font_size_px;
+                    }
+
+                    self.cursor_position = Some((x,y));
+                }
+            }
+        }
+    }
+
     pub fn on_virtual_key_down<T>(&mut self, app_state_no_data: &mut AppStateNoData<T>, event: &mut CallbackInfo<T>) -> UpdateScreen {
 
         let keyboard_state = app_state_no_data.windows[event.window_id].get_keyboard_state();
+        self.update_cursor_position(app_state_no_data,event);
 
         match keyboard_state.latest_virtual_keycode {
             Some(VirtualKeyCode::Back) => {
@@ -180,6 +258,7 @@ impl TextInputState {
     pub fn on_text_input<T>(&mut self, app_state_no_data: &mut AppStateNoData<T>, event: &mut CallbackInfo<T>) -> UpdateScreen {
 
         let keyboard_state = app_state_no_data.windows[event.window_id].get_keyboard_state();
+        self.update_cursor_position(app_state_no_data,event);
 
         match keyboard_state.current_char {
             Some(c) => {

--- a/azul/src/window_state.rs
+++ b/azul/src/window_state.rs
@@ -17,6 +17,7 @@ use {
     ui_state::UiState,
     callbacks::FocusTarget,
     app::AppState,
+    ui_solver::LayoutResult,
 };
 
 const DEFAULT_TITLE: &str = "Azul App";
@@ -211,6 +212,8 @@ pub struct WindowState {
     pub debug_state: DebugState,
     /// Size of the window + max width / max height: 800 x 600 by default
     pub size: WindowSize,
+    /// The last layout result
+    pub last_layout_result:Option<LayoutResult>,
     /// Current title of the window
     pub title: String,
     /// The x and y position, or None to let the WM decide where to put the window (default)
@@ -277,6 +280,7 @@ impl Default for WindowState {
             title: DEFAULT_TITLE.into(),
             position: None,
             size: WindowSize::default(),
+            last_layout_result: None,
             is_maximized: false,
             is_fullscreen: false,
             has_decorations: true,


### PR DESCRIPTION
I removed a lot of the cruft from the previous iteration of the cursor and tried to limit the changes a little bit. The LayoutResult is being moved into the WindowState and exposed to callbacks. This happens at the bottom of update_display_list, right before it would have gone out of scope- keeping it around shouldn't change performance too much.

Issues:
1. Cursor height isn't currently set. It's always the same height as the input widget, because I would prefer to set it programmatically but allow users to override it in CSS, and that isn't possible right now as far as I know.
2. Cursor is a little bit off when text overflows due to #142.
3. The cursor doesn't blink. With CSS this would have required animation/keyframes, and doing it programmatically would have been involved and hacky.
4. The cursor is always one-character delayed from the real position. This is because:
   1. The glyphs are laid out on the screen and LayoutResult is passed to the WindowState.
   2. The callbacks are triggered, and they calculate the position of the cursor.
   3. The callbacks change the text/position.
   4. -> back to i

    So when the text is displayed, the cursor is always positioned as it would have been in the last render. This is an issue that I'm not sure how to fix. My last attempt at this was re-calculating text width in the TextInputState in order to position the cursor for the *next* render, but it would be better not to  re-do the text layout again if we don't have to.