### PR TITLE
Fix for timers waiting a full interval before first run

### DIFF
--- a/azul/src/async.rs
+++ b/azul/src/async.rs
@@ -121,13 +121,19 @@ impl<T> Timer<T> {
             }
         }
 
-        if let Some(interval) = self.interval {
-            let last_run = match self.last_run {
-                Some(s) => s,
-                None => self.created + delay,
-            };
-            if instant_now - last_run < interval {
-                return (DontRedraw, TerminateTimer::Continue);
+        match self.last_run {
+            Some(last_run) => {
+                if let Some(interval) = self.interval {
+                    if instant_now - last_run < interval {
+                        return (DontRedraw, TerminateTimer::Continue);
+                    }
+                }
+
+            }
+            None => {
+                if instant_now < self.created + delay {
+                    return (DontRedraw, TerminateTimer::Continue);
+                }
             }
         }
 


### PR DESCRIPTION
As per [the documentation for delayed timers](https://github.com/maps4print/azul/blob/9090ce23a114222fcc08dc76b35381e671ab80e7/azul/src/async.rs#L54), a `Timer` should execute immediately when no delay is specified. However, if the timer is on an interval, it will wait a full interval before firing. This is especially problematic for timers with large intervals (e.g. querying a system's memory usage every 2 minutes).

This PR removes the initial interval delay. The old behavior is still possible by explicitly adding a delay, like so:

```rust
Timer::new(timer_function).with_delay(interval_time).with_interval(interval_time);

```