### PR TITLE
Fixed tests in azul-widgets

### DIFF
--- a/azul-widgets/button.rs
+++ b/azul-widgets/button.rs
@@ -46,17 +46,10 @@ impl Button {
 
 #[test]
 fn test_button_ui_1() {
-
-    use prelude::*;
-
     struct Mock;
 
-    let expected = DomXml::mock(r#"
-        <div class="__azul-native-button" focusable="true">
-            <p>Hello</p>
-        </div>
-    "#);
+    let expected = String::from("0 <div class=\"__azul-native-button\" tabindex=\"0\">\r\n1     <p>Hello</p>\r\n0 </div>\r\n");
     let button: Dom<Mock> = Button::with_label("Hello").dom();
 
-    expected.assert_eq(button);
+    assert_eq!(expected, button.debug_dump());
 }


### PR DESCRIPTION
I'm fixing the tests in all the projects. Every project will be it's own PR so that it won't be an overwhelming amount of changes.

`DomXml` is moved to `azul`, and `azul` depends on `azul-widgets`, so I resorted to using `debug_string`. Because of newline shenanigans I opted to use hard-coded `\r\n` instead of using `r#"..."` with newlines (because editors might update all line endings and they're a pain to fix)