### PR TITLE
Fixed the remaining 2 doc tests

### DIFF
--- a/azul/ui_solver.rs
+++ b/azul/ui_solver.rs
@@ -295,7 +295,7 @@ mod layout_tests {
     /// Returns a DOM for testing so we don't have to construct it every time.
     /// The DOM structure looks like this:
     ///
-    /// ```no_run
+    /// ```compile_fail
     /// 0
     /// '- 1
     ///    '-- 2

--- a/azul/xml.rs
+++ b/azul/xml.rs
@@ -178,7 +178,7 @@ impl<T> DomXml<T> {
     ///
     /// ## Example
     ///
-    /// ```rust
+    /// ```rust,ignore
     /// # use azul::dom::Dom;
     /// # use azul::xml::DomXml;
     /// let dom = DomXml::mock("<div id='test' />");


### PR DESCRIPTION
I think I missed these two doc tests.

The doc in `xml.rs` is interesting, because it's the documentation of a function that is behind a `#[cfg(test)]`  flag, referring another function also behind a `#[cfg(test)]` flag. The doc-test does test the function, but does not compile the other function because apparently the `#[cfg(test)]` flag is not set. I just disabled that doc-test for now.

As for `ui_solver.rs`, the phrase `no_run` means that it will still be compiled, just not run. To not compile the block at all, we should use `compile_fail` 