### PR TITLE
fix VS2019 build (#203)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,49 +3,49 @@
 [[package]]
 name = "adler32"
 version = "1.0.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "andrew"
 version = "0.2.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "line_drawing 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "rusttype 0.7.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "walkdir 2.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "xdg 2.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "line_drawing 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "rusttype 0.7.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "walkdir 2.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "xdg 2.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "android_glue"
 version = "0.2.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "app_units"
 version = "0.7.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "approx"
 version = "0.3.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "arrayvec"
 version = "0.4.8"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "nodrop 0.1.13 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "nodrop 0.1.13 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -60,7 +60,7 @@ dependencies = [
  "azul-core 0.1.0",
  "azul-css 0.1.0",
  "azul-css-parser 0.1.0",
- "azul-dependencies 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "azul-dependencies 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
  "azul-layout 0.1.0",
  "azul-native-style 0.1.0",
  "azul-widgets 0.1.0",
@@ -94,28 +94,28 @@ dependencies = [
 [[package]]
 name = "azul-dependencies"
 version = "0.1.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "backtrace 0.3.12 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "clipboard2 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "fern 0.5.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "font-loader 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "glium 0.22.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "harfbuzz-sys 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "image 0.20.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lyon 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "rusttype 0.7.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "stb_truetype 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "tinyfiledialogs 3.3.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "unicode-normalization 0.1.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "usvg 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "webrender 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "backtrace 0.3.12 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "clipboard2 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "fern 0.5.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "font-loader 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "glium 0.22.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "harfbuzz-sys 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "image 0.20.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lyon 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "rusttype 0.7.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "stb_truetype 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "tinyfiledialogs 3.3.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "unicode-normalization 0.1.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "usvg 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "webrender 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ version = "0.1.0"
 dependencies = [
  "azul-core 0.1.0",
  "azul-css 0.1.0",
- "azul-dependencies 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "azul-dependencies 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
  "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -154,51 +154,51 @@ dependencies = [
 [[package]]
 name = "backtrace"
 version = "0.3.12"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "backtrace-sys 0.1.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "rustc-demangle 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "backtrace-sys 0.1.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "rustc-demangle 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "backtrace-sys"
 version = "0.1.24"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "base64"
 version = "0.9.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "safemem 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "safemem 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "binary-space-partition"
 version = "0.1.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "bincode"
 version = "1.0.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "bitflags"
 version = "1.0.4"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "bitflags"
@@ -213,17 +213,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byteorder"
 version = "1.2.7"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "cc"
 version = "1.0.26"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
+
+[[package]]
+name = "cc"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.6"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "cfg-if"
@@ -233,7 +238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cgl"
 version = "0.2.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -242,57 +247,57 @@ dependencies = [
 [[package]]
 name = "clipboard-win"
 version = "2.1.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "clipboard2"
 version = "0.1.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "clipboard-win 2.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "objc-foundation 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "objc_id 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "x11-clipboard 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "clipboard-win 2.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "objc-foundation 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "objc_id 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "x11-clipboard 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "cmake"
-version = "0.1.35"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+version = "0.1.40"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cocoa"
 version = "0.18.4"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "color_quant"
 version = "1.0.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "core-foundation"
 version = "0.6.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -303,10 +308,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "core-graphics"
 version = "0.17.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -314,10 +319,10 @@ dependencies = [
 [[package]]
 name = "core-text"
 version = "13.1.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -325,111 +330,111 @@ dependencies = [
 [[package]]
 name = "crc32fast"
 version = "1.1.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "crossbeam-deque"
 version = "0.2.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "crossbeam-epoch 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "crossbeam-utils 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "crossbeam-epoch 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "crossbeam-utils 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
 version = "0.3.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "crossbeam-utils 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "memoffset 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "nodrop 0.1.13 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "scopeguard 0.3.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "crossbeam-utils 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "memoffset 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "nodrop 0.1.13 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "scopeguard 0.3.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "crossbeam-utils"
 version = "0.2.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "deflate"
 version = "0.7.19"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "dlib"
 version = "0.4.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "libloading 0.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libloading 0.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "downcast-rs"
 version = "1.0.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "dwrote"
 version = "0.6.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "either"
 version = "1.5.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "euclid"
 version = "0.19.4"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "expat-sys"
 version = "2.1.6"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cmake 0.1.35 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cmake 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "fern"
 version = "0.5.7"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "float-cmp"
 version = "0.4.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -437,18 +442,18 @@ dependencies = [
 [[package]]
 name = "fnv"
 version = "1.0.6"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "font-loader"
 version = "0.8.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-text 13.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "servo-fontconfig 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-text 13.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "servo-fontconfig 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -467,37 +472,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "freetype"
 version = "0.4.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "servo-freetype-sys 4.0.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "servo-freetype-sys 4.0.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "gif"
 version = "0.10.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "color_quant 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "color_quant 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "gl_generator"
 version = "0.10.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "khronos_api 3.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "khronos_api 3.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -521,86 +526,86 @@ dependencies = [
 [[package]]
 name = "glium"
 version = "0.22.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "fnv 1.0.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "gl_generator 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "glutin 0.19.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "smallvec 0.6.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "fnv 1.0.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "gl_generator 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "glutin 0.19.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "smallvec 0.6.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "glutin"
 version = "0.19.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "android_glue 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cgl 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cocoa 0.18.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "gl_generator 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libloading 0.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "osmesa-sys 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "shared_library 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winit 0.18.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "x11-dl 2.18.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "android_glue 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cgl 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cocoa 0.18.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "gl_generator 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libloading 0.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "osmesa-sys 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "shared_library 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winit 0.18.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "x11-dl 2.18.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "harfbuzz-sys"
 version = "0.3.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cmake 0.1.35 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "freetype 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cmake 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "freetype 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "image"
 version = "0.20.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "gif 0.10.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "jpeg-decoder 0.1.15 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-iter 0.1.37 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-rational 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "png 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "scoped_threadpool 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "tiff 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "gif 0.10.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "jpeg-decoder 0.1.15 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-iter 0.1.37 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-rational 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "png 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "scoped_threadpool 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "tiff 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "inflate"
 version = "0.4.4"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "jpeg-decoder"
 version = "0.1.15"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "rayon 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "rayon 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "khronos_api"
 version = "3.0.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "khronos_api"
@@ -610,12 +615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "lazy_static"
 version = "1.2.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "libc"
 version = "0.2.45"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "libc"
@@ -625,36 +630,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libflate"
 version = "0.1.19"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "crc32fast 1.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "crc32fast 1.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.5.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "line_drawing"
 version = "0.7.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.6"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -668,61 +673,61 @@ dependencies = [
 [[package]]
 name = "lyon"
 version = "0.11.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "lyon_algorithms 0.11.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lyon_tessellation 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lyon_algorithms 0.11.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lyon_tessellation 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "lyon_algorithms"
 version = "0.11.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "lyon_path 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lyon_path 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "lyon_geom"
 version = "0.11.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "lyon_geom"
 version = "0.12.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "lyon_path"
 version = "0.11.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "lyon_geom 0.11.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lyon_geom 0.11.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "lyon_tessellation"
 version = "0.11.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "lyon_path 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "sid 0.5.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lyon_path 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "sid 0.5.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "lzw"
 version = "0.10.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "malloc_buf"
@@ -735,75 +740,75 @@ dependencies = [
 [[package]]
 name = "memmap"
 version = "0.7.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "memoffset"
 version = "0.2.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "nix"
 version = "0.12.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "void 1.0.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "void 1.0.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "nodrop"
 version = "0.1.13"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "num-derive"
 version = "0.2.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "syn 0.15.22 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "syn 0.15.22 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "num-integer"
 version = "0.1.39"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "num-iter"
 version = "0.1.37"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-integer 0.1.39 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-integer 0.1.39 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "num-rational"
 version = "0.2.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-integer 0.1.39 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-integer 0.1.39 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.6"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "num-traits"
@@ -816,15 +821,15 @@ dependencies = [
 [[package]]
 name = "num_cpus"
 version = "1.9.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "objc"
 version = "0.2.5"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -832,91 +837,91 @@ dependencies = [
 [[package]]
 name = "objc-foundation"
 version = "0.1.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "objc_id 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "objc_id 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "objc_id"
 version = "0.1.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "ordered-float"
 version = "1.0.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "osmesa-sys"
 version = "0.1.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "shared_library 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "shared_library 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "percent-encoding"
 version = "1.0.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "phf"
 version = "0.7.23"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "phf_shared 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "phf_shared 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "phf_shared"
 version = "0.7.23"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "siphasher 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "siphasher 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "pkg-config"
 version = "0.3.14"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "plane-split"
 version = "0.13.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "binary-space-partition 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "binary-space-partition 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "png"
 version = "0.12.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "deflate 0.7.19 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "inflate 0.4.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-iter 0.1.37 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "deflate 0.7.19 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "inflate 0.4.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-iter 0.1.37 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "0.4.24"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "unicode-xid 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "unicode-xid 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -930,9 +935,9 @@ dependencies = [
 [[package]]
 name = "quote"
 version = "0.6.10"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -946,62 +951,62 @@ dependencies = [
 [[package]]
 name = "rayon"
 version = "1.0.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "crossbeam-deque 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "either 1.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "rayon-core 1.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "crossbeam-deque 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "either 1.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "rayon-core 1.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "rayon-core"
 version = "1.4.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "crossbeam-deque 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num_cpus 1.9.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "crossbeam-deque 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num_cpus 1.9.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "rctree"
 version = "0.2.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "roxmltree"
 version = "0.1.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "rustc-demangle"
 version = "0.1.9"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "rusttype"
 version = "0.7.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "approx 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "ordered-float 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "stb_truetype 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "approx 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "ordered-float 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "stb_truetype 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "safemem"
 version = "0.3.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "same-file"
 version = "1.0.4"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1009,19 +1014,19 @@ dependencies = [
 [[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "scopeguard"
 version = "0.3.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "serde"
 version = "1.0.80"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -1032,19 +1037,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "serde_bytes"
 version = "0.10.4"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.80"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "syn 0.15.22 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "syn 0.15.22 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -1060,125 +1065,125 @@ dependencies = [
 [[package]]
 name = "servo-fontconfig"
 version = "0.4.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "servo-fontconfig-sys 4.0.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "servo-fontconfig-sys 4.0.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "servo-fontconfig-sys"
 version = "4.0.7"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "expat-sys 2.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "servo-freetype-sys 4.0.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "expat-sys 2.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "servo-freetype-sys 4.0.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "servo-freetype-sys"
 version = "4.0.5"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cmake 0.1.35 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cmake 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "shared_library"
 version = "0.1.9"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "sid"
 version = "0.5.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "simplecss"
 version = "0.1.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "siphasher"
 version = "0.2.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "slab"
 version = "0.4.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "smallvec"
 version = "0.6.7"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "unreachable 1.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "unreachable 1.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "smithay-client-toolkit"
 version = "0.6.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "andrew 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "dlib 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "memmap 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-protocols 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "andrew 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "dlib 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "memmap 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-protocols 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "stb_truetype"
 version = "0.2.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "svgdom"
 version = "0.14.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "roxmltree 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "simplecss 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "slab 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "svgtypes 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "roxmltree 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "simplecss 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "slab 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "svgtypes 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "svgtypes"
 version = "0.2.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "float-cmp 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "phf 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "float-cmp 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "phf 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "syn"
 version = "0.15.22"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "unicode-xid 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "unicode-xid 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -1194,51 +1199,51 @@ dependencies = [
 [[package]]
 name = "thread_profiler"
 version = "0.1.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "tiff"
 version = "0.2.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-derive 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-derive 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "time"
 version = "0.1.40"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "tinyfiledialogs"
 version = "3.3.5"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "unicode-normalization"
 version = "0.1.7"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.2.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "unicode-xid"
@@ -1248,147 +1253,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unreachable"
 version = "1.0.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "void 1.0.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "void 1.0.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "usvg"
 version = "0.3.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "base64 0.9.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libflate 0.1.19 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lyon_geom 0.12.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "rctree 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "svgdom 0.14.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "unicode-segmentation 1.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "base64 0.9.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libflate 0.1.19 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lyon_geom 0.12.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "rctree 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "svgdom 0.14.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "unicode-segmentation 1.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "void"
 version = "1.0.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "walkdir"
 version = "2.2.7"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "same-file 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "same-file 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-client"
 version = "0.23.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "downcast-rs 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-commons 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-scanner 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-sys 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "downcast-rs 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-commons 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-scanner 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-sys 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "wayland-commons"
 version = "0.23.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-sys 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-sys 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "wayland-protocols"
 version = "0.23.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-commons 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-scanner 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-commons 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-scanner 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "wayland-scanner"
 version = "0.23.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "wayland-sys"
 version = "0.23.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "dlib 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "dlib 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "webrender"
 version = "0.57.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "bincode 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-text 13.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "dwrote 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "freetype 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "fxhash 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "bincode 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-text 13.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "dwrote 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "freetype 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "fxhash 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
  "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "plane-split 0.13.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "rayon 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "smallvec 0.6.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "thread_profiler 0.1.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "time 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "webrender_api 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "plane-split 0.13.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "rayon 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "smallvec 0.6.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "thread_profiler 0.1.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "time 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "webrender_api 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "webrender_api"
 version = "0.57.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "bincode 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "dwrote 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde_bytes 0.10.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "time 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "bincode 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "dwrote 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde_bytes 0.10.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "time 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "winapi"
 version = "0.3.6"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "winapi-i686-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
@@ -1403,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1421,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1431,60 +1436,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "winit"
 version = "0.18.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "android_glue 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "cocoa 0.18.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "image 0.20.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "percent-encoding 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "smithay-client-toolkit 0.6.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "x11-dl 2.18.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "android_glue 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "cocoa 0.18.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "image 0.20.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "percent-encoding 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "smithay-client-toolkit 0.6.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "x11-dl 2.18.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "x11-clipboard"
 version = "0.3.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "xcb 0.8.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "xcb 0.8.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "x11-dl"
 version = "2.18.3"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "xcb"
 version = "0.8.2"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 dependencies = [
- "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
- "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)",
+ "libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
+ "log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)",
 ]
 
 [[package]]
 name = "xdg"
 version = "2.2.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "xml-rs"
 version = "0.8.0"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [[package]]
 name = "xml-rs"
@@ -1494,174 +1499,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "xmlparser"
 version = "0.6.1"
-source = "git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457#bf2933b9aac43a7003278862772250398e4fa457"
+source = "git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992#00e6e0ffacb008244d196df246db48f463a59992"
 
 [metadata]
-"checksum adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum andrew 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum android_glue 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum approx 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum adler32 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum andrew 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum android_glue 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum app_units 0.7.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum approx 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum arrayvec 0.4.8 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
-"checksum azul-dependencies 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum azul-dependencies 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum azul-simplecss 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c303bfdf857413adbd19d9b15dddd9b4adb8e2be7e493c8a38d9fc6179a074ac"
-"checksum backtrace 0.3.12 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum backtrace-sys 0.1.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum base64 0.9.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum binary-space-partition 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum bincode 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum backtrace 0.3.12 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum backtrace-sys 0.1.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum base64 0.9.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum binary-space-partition 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum bincode 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum bitflags 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-"checksum byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum byteorder 1.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum cc 1.0.26 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
+"checksum cfg-if 0.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum cgl 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum clipboard-win 2.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum clipboard2 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum cmake 0.1.35 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum cocoa 0.18.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum color_quant 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum cgl 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum clipboard-win 2.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum clipboard2 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum cmake 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum cocoa 0.18.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum color_quant 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum core-foundation 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
-"checksum core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum core-text 13.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum crc32fast 1.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum crossbeam-deque 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum crossbeam-epoch 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum crossbeam-utils 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum deflate 0.7.19 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum dlib 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum downcast-rs 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum dwrote 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum either 1.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum expat-sys 2.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum fern 0.5.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum float-cmp 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum fnv 1.0.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum font-loader 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum core-graphics 0.17.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum core-text 13.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum crc32fast 1.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum crossbeam-deque 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum crossbeam-epoch 0.3.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum crossbeam-utils 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum deflate 0.7.19 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum dlib 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum downcast-rs 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum dwrote 0.6.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum either 1.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum euclid 0.19.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum expat-sys 2.1.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum fern 0.5.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum float-cmp 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum fnv 1.0.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum font-loader 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-"checksum freetype 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum fxhash 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum gif 0.10.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum gl_generator 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum freetype 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum fxhash 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum gif 0.10.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum gl_generator 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a23d5e872a275135d66895d954269cf5e8661d234eb1c2480f4ce0d586acbd"
 "checksum gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7f46fd8874e043ffac0d638ed1567a2584f7814f6d72b4db37ab1689004a26c4"
-"checksum glium 0.22.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum glutin 0.19.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum harfbuzz-sys 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum image 0.20.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum inflate 0.4.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum jpeg-decoder 0.1.15 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum khronos_api 3.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum glium 0.22.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum glutin 0.19.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum harfbuzz-sys 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum image 0.20.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum inflate 0.4.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum jpeg-decoder 0.1.15 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum khronos_api 3.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-"checksum lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum lazy_static 1.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum libc 0.2.45 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
-"checksum libflate 0.1.19 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum libloading 0.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum line_drawing 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum libflate 0.1.19 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum libloading 0.5.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum line_drawing 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum log 0.4.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum lyon 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum lyon_algorithms 0.11.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum lyon_geom 0.11.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum lyon_geom 0.12.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum lyon_path 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum lyon_tessellation 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum lyon 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum lyon_algorithms 0.11.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum lyon_geom 0.11.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum lyon_geom 0.12.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum lyon_path 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum lyon_tessellation 0.11.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum lzw 0.10.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum memmap 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum memoffset 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum nodrop 0.1.13 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum num-derive 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum num-integer 0.1.39 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum num-iter 0.1.37 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum num-rational 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum memmap 0.7.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum memoffset 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum nix 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum nodrop 0.1.13 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum num-derive 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum num-integer 0.1.39 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum num-iter 0.1.37 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum num-rational 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum num-traits 0.2.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c79c952a4a139f44a0fe205c4ee66ce239c0e6ce72cd935f5f7e2f717549dd"
-"checksum num_cpus 1.9.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum objc-foundation 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum objc_id 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum ordered-float 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum osmesa-sys 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum percent-encoding 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum phf 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum phf_shared 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum plane-split 0.13.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum png 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum num_cpus 1.9.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum objc 0.2.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum objc-foundation 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum objc_id 0.1.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum ordered-float 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum osmesa-sys 0.1.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum percent-encoding 1.0.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum phf 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum phf_shared 0.7.23 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum pkg-config 0.3.14 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum plane-split 0.13.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum png 0.12.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum proc-macro2 0.4.24 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum quote 0.6.10 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
-"checksum rayon 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum rayon-core 1.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum rctree 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum roxmltree 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum rustc-demangle 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum rusttype 0.7.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum safemem 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum same-file 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum scoped_threadpool 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum scopeguard 0.3.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum rayon 1.0.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum rayon-core 1.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum rctree 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum roxmltree 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum rustc-demangle 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum rusttype 0.7.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum safemem 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum same-file 1.0.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum scoped_threadpool 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum scopeguard 0.3.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum serde 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
-"checksum serde_bytes 0.10.4 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum serde_bytes 0.10.4 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum serde_derive 1.0.80 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "101b495b109a3e3ca8c4cbe44cf62391527cdfb6ba15821c5ce80bcd5ea23f9f"
-"checksum servo-fontconfig 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum servo-fontconfig-sys 4.0.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum servo-freetype-sys 4.0.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum shared_library 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum sid 0.5.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum simplecss 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum siphasher 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum slab 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum smallvec 0.6.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum smithay-client-toolkit 0.6.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum stb_truetype 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum svgdom 0.14.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum svgtypes 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum syn 0.15.22 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum servo-fontconfig 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum servo-fontconfig-sys 4.0.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum servo-freetype-sys 4.0.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum shared_library 0.1.9 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum sid 0.5.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum simplecss 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum siphasher 0.2.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum slab 0.4.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum smallvec 0.6.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum smithay-client-toolkit 0.6.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum stb_truetype 0.2.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum svgdom 0.14.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum svgtypes 0.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum syn 0.15.22 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
-"checksum thread_profiler 0.1.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum tiff 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum time 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum tinyfiledialogs 3.3.5 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum unicode-normalization 0.1.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum unicode-segmentation 1.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum unicode-xid 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum thread_profiler 0.1.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum tiff 0.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum time 0.1.40 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum tinyfiledialogs 3.3.5 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum unicode-normalization 0.1.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum unicode-segmentation 1.2.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum unicode-xid 0.1.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unreachable 1.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum usvg 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum void 1.0.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum walkdir 2.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum wayland-commons 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum wayland-protocols 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum wayland-scanner 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum wayland-sys 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum webrender 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum webrender_api 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum unreachable 1.0.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum usvg 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum void 1.0.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum walkdir 2.2.7 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum wayland-client 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum wayland-commons 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum wayland-protocols 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum wayland-scanner 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum wayland-sys 0.23.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum webrender 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum webrender_api 0.57.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum winapi 0.3.6 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.18.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum x11-clipboard 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum x11-dl 2.18.3 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum xcb 0.8.2 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum xdg 2.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
-"checksum xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum winit 0.18.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum x11-clipboard 0.3.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum x11-dl 2.18.3 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum xcb 0.8.2 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum xdg 2.2.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
+"checksum xml-rs 0.8.0 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
-"checksum xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=bf2933b9aac43a7003278862772250398e4fa457)" = "<none>"
+"checksum xmlparser 0.6.1 (git+https://github.com/maps4print/azul-dependencies?rev=00e6e0ffacb008244d196df246db48f463a59992)" = "<none>"

--- a/cargo/azul-widgets/Cargo.toml
+++ b/cargo/azul-widgets/Cargo.toml
@@ -22,7 +22,7 @@ path = "../../azul-widgets/lib.rs"
 azul-core               = { version = "0.1.0",                  path = "../azul-core"                             }
 azul-css                = { version = "0.1.0",                  path = "../azul-css"                              }
 gleam                   = { version = "0.6",                    optional = true                                   }
-azul-dependencies       = { version = "0.1.0",                  optional = true,        git = "https://github.com/maps4print/azul-dependencies", rev = "bf2933b9aac43a7003278862772250398e4fa457" }
+azul-dependencies       = { version = "0.1.0",                  optional = true,        git = "https://github.com/maps4print/azul-dependencies", rev = "00e6e0ffacb008244d196df246db48f463a59992" }
 serde_derive            = { version = "1",                    optional = true }
 serde                   = { version = "1",                    optional = true }
 

--- a/cargo/azul/Cargo.toml
+++ b/cargo/azul/Cargo.toml
@@ -27,7 +27,7 @@ azul-layout             = { version = "0.1.0",                path = "../azul-la
 azul-css-parser         = { version = "0.1.0",                path = "../azul-css-parser",      optional = true }
 azul-widgets            = { version = "0.1.0",                path = "../azul-widgets",         optional = true }
 azul-native-style       = { version = "0.1.0",                path = "../azul-native-style",    optional = true }
-azul-dependencies       = { version = "0.1.0",                git = "https://github.com/maps4print/azul-dependencies", rev = "bf2933b9aac43a7003278862772250398e4fa457" }
+azul-dependencies       = { version = "0.1.0",                git = "https://github.com/maps4print/azul-dependencies", rev = "00e6e0ffacb008244d196df246db48f463a59992" }
 serde_derive            = { version = "1",                    optional = true }
 serde                   = { version = "1",                    optional = true }
 gleam                   = { version = "0.6"                                                                     }


### PR DESCRIPTION
Use the commit in to updte to cmake-0.1.40 which is already present on azul-dependencies