### PR TITLE
Fix #245 x86_64-pc-windows-msvc LLP64 supporting

### DIFF
--- a/azul-text-layout/text_shaping.rs
+++ b/azul-text-layout/text_shaping.rs
@@ -272,12 +272,13 @@ pub fn get_font_metrics_freetype(font_bytes: &[u8], font_index: i32) -> FontMetr
 
     use std::convert::TryInto;
     use freetype::freetype::{
+        FT_Long, FT_F26Dot6,
         FT_Init_FreeType, FT_Done_FreeType, FT_New_Memory_Face,
         FT_Done_Face, FT_Set_Char_Size, FT_Library, FT_Face,
     };
 
     const FT_ERR_OK: i32 = 0;
-    const FAKE_FONT_SIZE: i64 = 1000;
+    const FAKE_FONT_SIZE: FT_F26Dot6 = 1000;
 
     let mut baseline = FontMetrics {
         font_size: FAKE_FONT_SIZE as usize,
@@ -291,7 +292,7 @@ pub fn get_font_metrics_freetype(font_bytes: &[u8], font_index: i32) -> FontMetr
         max_advance: 0,
     };
 
-    let buf_len: i64 = match font_bytes.len().try_into().ok() {
+    let buf_len: FT_Long = match font_bytes.len().try_into().ok() {
         Some(s) => s,
         None => return baseline, // font too large for freetype
     };
@@ -306,7 +307,7 @@ pub fn get_font_metrics_freetype(font_bytes: &[u8], font_index: i32) -> FontMetr
 
         // Load font
         let mut ft_face: FT_Face = ptr::null_mut();
-        let error = FT_New_Memory_Face(ft_library, font_bytes.as_ptr(), buf_len, font_index as i64, &mut ft_face);
+        let error = FT_New_Memory_Face(ft_library, font_bytes.as_ptr(), buf_len, font_index as FT_Long, &mut ft_face);
         if error != FT_ERR_OK {
             FT_Done_FreeType(ft_library);
             return baseline;
@@ -330,12 +331,12 @@ pub fn get_font_metrics_freetype(font_bytes: &[u8], font_index: i32) -> FontMetr
             font_size: FAKE_FONT_SIZE as usize,
             x_ppem: metrics.x_ppem,
             y_ppem: metrics.y_ppem,
-            x_scale: metrics.x_scale,
-            y_scale: metrics.y_scale,
-            ascender: metrics.ascender,
-            descender: metrics.descender,
-            height: metrics.height,
-            max_advance: metrics.max_advance,
+            x_scale: metrics.x_scale as i64,
+            y_scale: metrics.y_scale as i64,
+            ascender: metrics.ascender as i64,
+            descender: metrics.descender as i64,
+            height: metrics.height as i64,
+            max_advance: metrics.max_advance as i64,
         };
 
         FT_Done_Face(ft_face);


### PR DESCRIPTION
1. Add `use`: `FT_Long` and `FT_F26Dot6`.
2. Modify `i64` to `FT_Long` and `FT_F26Dot6` for `FT_New_Memory_Face`.
3. Add `as i64` for `FontMetrics` parameters.