### PR TITLE
[wip branch] Some fixes to windows build and travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 sudo: required
 rust:
-  - 1.33.0
+  - 1.41.0
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 sudo: required
 rust:
-  - 1.41.0
+  - 1.44.0
 
 matrix:
   fast_finish: true

--- a/azul-core/src/app_resources.rs
+++ b/azul-core/src/app_resources.rs
@@ -906,7 +906,8 @@ pub struct FontInstancePlatformOptions {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct FontInstancePlatformOptions {
     pub gamma: u16,
-    pub contrast: u16,
+    pub contrast: u8,
+    pub cleartype_level: u8,
 }
 
 #[cfg(target_os = "macos")]
@@ -1331,6 +1332,7 @@ pub fn build_add_font_resource_updates<T: FontImageApi>(
                 let platform_options = FontInstancePlatformOptions {
                     gamma: 300,
                     contrast: 100,
+                    cleartype_level: 100,
                 };
 
                 #[cfg(target_os = "linux")]

--- a/azul-core/src/window.rs
+++ b/azul-core/src/window.rs
@@ -7,8 +7,6 @@ use std::{
     path::PathBuf,
     ffi::c_void,
 };
-#[cfg(target_os = "windows")]
-use std::ffi::c_void;
 use azul_css::{U8Vec, AzString, Css, LayoutPoint, LayoutRect, CssPath};
 use crate::{
     FastHashMap,

--- a/azul-desktop/src/window.rs
+++ b/azul-desktop/src/window.rs
@@ -396,9 +396,9 @@ fn create_window_builder_windows(
     let mut window_builder = GlutinWindowBuilder::new()
         .with_transparent(has_transparent_background)
         .with_no_redirection_bitmap(platform_options.no_redirection_bitmap)
-        .with_taskbar_icon(platform_options.taskbar_icon.clone().and_then(|ic| translate_taskbar_icon(ic).ok()));
+        .with_taskbar_icon(platform_options.taskbar_icon.clone().into_option().and_then(|ic| translate_taskbar_icon(ic).ok()));
 
-    if let Some(parent_window) = platform_options.parent_window {
+    if let Some(parent_window) = platform_options.parent_window.into_option() {
         window_builder = window_builder.with_parent_window(parent_window as *mut _);
     }
 
@@ -680,11 +680,11 @@ fn synchronize_os_window_windows_extensions(
     use crate::wr_translate::winit_translate::{translate_window_icon, translate_taskbar_icon};
 
     if old_state.window_icon != new_state.window_icon {
-        window.set_window_icon(new_state.window_icon.clone().and_then(|ic| translate_window_icon(ic).ok()));
+        window.set_window_icon(new_state.window_icon.clone().into_option().and_then(|ic| translate_window_icon(ic).ok()));
     }
 
     if old_state.taskbar_icon != new_state.taskbar_icon {
-        window.set_taskbar_icon(new_state.taskbar_icon.clone().and_then(|ic| translate_taskbar_icon(ic).ok()));
+        window.set_taskbar_icon(new_state.taskbar_icon.clone().into_option().and_then(|ic| translate_taskbar_icon(ic).ok()));
     }
 }
 
@@ -745,8 +745,8 @@ fn initialize_os_window_windows_extensions(
     use glutin::platform::windows::WindowExtWindows;
     use crate::wr_translate::winit_translate::{translate_taskbar_icon, translate_window_icon};
 
-    window.set_window_icon(new_state.window_icon.clone().and_then(|ic| translate_window_icon(ic).ok()));
-    window.set_taskbar_icon(new_state.taskbar_icon.clone().and_then(|ic| translate_taskbar_icon(ic).ok()));
+    window.set_window_icon(new_state.window_icon.clone().into_option().and_then(|ic| translate_window_icon(ic).ok()));
+    window.set_taskbar_icon(new_state.taskbar_icon.clone().into_option().and_then(|ic| translate_taskbar_icon(ic).ok()));
 }
 
 // Linux-specific window options

--- a/azul-desktop/src/wr_translate.rs
+++ b/azul-desktop/src/wr_translate.rs
@@ -731,6 +731,7 @@ const fn wr_translate_font_instance_platform_options(fio: FontInstancePlatformOp
     WrFontInstancePlatformOptions {
         gamma: fio.gamma,
         contrast: fio.contrast,
+        cleartype_level: fio.cleartype_level,
     }
 }
 


### PR DESCRIPTION
This makes azul-dll installable _(cargo install --path azul-dll)_ on Windows, also updates travis config so it's not stuck due to rust version feature incompatibilities.